### PR TITLE
fix: add Google OAuth domains to Content-Security-Policy

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -167,11 +167,12 @@ async def add_security_headers(request, call_next):
         response.headers["Cross-Origin-Resource-Policy"] = "same-site"
     response.headers["Content-Security-Policy"] = (
         "default-src 'self'; "
-        "script-src 'self'; "
-        "style-src 'self' 'unsafe-inline'; "
-        "img-src 'self' data: https://images.unsplash.com https://*.pellicura.com; "
-        "connect-src 'self' https://api.openai.com wss://*.pellicura.com; "
+        "script-src 'self' https://accounts.google.com https://apis.google.com; "
+        "style-src 'self' 'unsafe-inline' https://accounts.google.com; "
+        "img-src 'self' data: https://images.unsplash.com https://*.pellicura.com https://*.googleusercontent.com; "
+        "connect-src 'self' https://api.openai.com https://accounts.google.com https://oauth2.googleapis.com https://*.pellicura.com wss://*.pellicura.com; "
         "font-src 'self'; "
+        "frame-src https://accounts.google.com; "
         "frame-ancestors 'none'"
     )
     if not settings.DEBUG:


### PR DESCRIPTION
CSP was blocking Google OAuth sign-in flow. Added:
- accounts.google.com to script-src, style-src, connect-src
- oauth2.googleapis.com to connect-src
- apis.google.com to script-src
- googleusercontent.com to img-src
- frame-src for Google sign-in popup

https://claude.ai/code/session_016XpCGMkdoVXBdD3E6dHejV

### Summary

- **What**: One-line summary of the change
- **Why**: Short justification and links to SRS/backlog

### Changes

- Files and modules changed (example: `backend/app/services/auth_service.py`)

### How to run / test locally

```bash
cd backend
pytest -q
```

### Checklist

- [ ] Tests added or updated
- [ ] Documentation updated (`docs/PROJECT_PROGRESS_TRACKER.md` or relevant doc)
- [ ] Env changes documented (`backend/.env.example`)
- [ ] DB migrations added (if schema changes)

### Notes for reviewers

- Any important notes about the change, deployment steps, or potential impacts
