### PR TITLE
fix: update scan history parsing from .scans to .data across 9 files

### DIFF
--- a/frontend/src/context/ScanContext.tsx
+++ b/frontend/src/context/ScanContext.tsx
@@ -35,7 +35,11 @@ export function ScanProvider({ children }: { children: React.ReactNode }) {
     queryKey: queryKeys.scans.history(user?.id ?? 0),
     queryFn: async () => {
       const data = await getScanHistory();
-      const items = Array.isArray(data) ? data : (data as { scans?: ScanHistoryItem[] }).scans || [];
+      const items = Array.isArray(data)
+        ? data
+        : (data as { data?: ScanHistoryItem[]; scans?: ScanHistoryItem[] }).data
+          || (data as { scans?: ScanHistoryItem[] }).scans
+          || [];
       return items as ScanHistoryItem[];
     },
     enabled: !!user,

--- a/frontend/src/pages/AnalysisResults.tsx
+++ b/frontend/src/pages/AnalysisResults.tsx
@@ -146,7 +146,7 @@ const AnalysisResults: React.FC = () => {
         setFailureMessage('No analysis data returned. Please retry the scan with a clear, front-facing selfie.');
       }
       setAnalysis(mapped);
-      const scans = (historyData as { scans?: ScanHistoryItem[] }).scans || [];
+      const scans = ((historyData as Record<string, unknown>).data || (historyData as Record<string, unknown>).scans || []) as ScanHistoryItem[];
       setPreviousScans(scans);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An error occurred');

--- a/frontend/src/pages/ComparisonPage.tsx
+++ b/frontend/src/pages/ComparisonPage.tsx
@@ -42,7 +42,7 @@ const ComparisonPage: React.FC = () => {
     const fetchAnalyses = async () => {
       try {
         const historyData = await getScanHistory();
-        const scans = (historyData as { scans?: Array<Record<string, unknown>> }).scans || [];
+        const scans = (historyData as Record<string, unknown>).data as Array<Record<string, unknown>> || (historyData as Record<string, unknown>).scans as Array<Record<string, unknown>> || [];
 
         const mapped = scans.map((scan) => {
           const summary = (scan.summary || {}) as Record<string, unknown>;

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -114,7 +114,7 @@ const DashboardPage: React.FC = () => {
     try {
       setLoading(true);
       const historyData = await getScanHistory();
-      const scans = (historyData as { scans?: Array<Record<string, unknown>> }).scans || [];
+      const scans = (historyData as Record<string, unknown>).data as Array<Record<string, unknown>> || (historyData as Record<string, unknown>).scans as Array<Record<string, unknown>> || [];
       const completedScans = scans.filter((scan) => String(scan.status || '') !== 'failed');
       const scores = completedScans
         .map((scan) => {

--- a/frontend/src/pages/DataExportPage.tsx
+++ b/frontend/src/pages/DataExportPage.tsx
@@ -48,7 +48,7 @@ const DataExportPage: React.FC = () => {
       const exportData = {
         user: data.user,
         profile: includeProfile ? data.profile : null,
-        analysis: includeAnalysis ? (data.scans || []) : null,
+        analysis: includeAnalysis ? (data.data || data.scans || []) : null,
         products: includeProducts ? { favorites: favoriteIds } : null,
         export_timestamp: data.export_timestamp,
       };

--- a/frontend/src/pages/HistoryPage.tsx
+++ b/frontend/src/pages/HistoryPage.tsx
@@ -36,7 +36,7 @@ const HistoryPage: React.FC = () => {
     try {
       setLoading(true);
       const historyData = await getScanHistory();
-      const scans = (historyData as { scans?: Array<Record<string, unknown>> }).scans || [];
+      const scans = (historyData as Record<string, unknown>).data as Array<Record<string, unknown>> || (historyData as Record<string, unknown>).scans as Array<Record<string, unknown>> || [];
       const mapped = scans.map((scan) => {
         const summary = (scan.summary || {}) as Record<string, unknown>;
         const concerns = Array.isArray(summary.concerns)

--- a/frontend/src/pages/MePage.tsx
+++ b/frontend/src/pages/MePage.tsx
@@ -41,8 +41,8 @@ const MePage: React.FC = () => {
     if (!isAuthenticated) return;
     getScanHistory()
       .then((d) => {
-        const res = d as { scans?: Array<{ summary?: { overall_score?: number } }> };
-        const scans = res.scans ?? [];
+        const res = d as { data?: Array<{ summary?: { overall_score?: number } }>; scans?: Array<{ summary?: { overall_score?: number } }> };
+        const scans = res.data ?? res.scans ?? [];
         setScanCount(scans.length);
         const scores = scans
           .map((s) => (s.summary && typeof s.summary.overall_score === 'number' ? Math.round(s.summary.overall_score) : null))

--- a/frontend/src/pages/ProfileSettingsPage.tsx
+++ b/frontend/src/pages/ProfileSettingsPage.tsx
@@ -260,7 +260,7 @@ const ProfileSettingsPage: React.FC = () => {
     const loadStats = async () => {
       try {
         const historyData = await getScanHistory();
-        const scans = (historyData as { scans?: Array<Record<string, unknown>> }).scans || [];
+        const scans = (historyData as Record<string, unknown>).data as Array<Record<string, unknown>> || (historyData as Record<string, unknown>).scans as Array<Record<string, unknown>> || [];
         const completedScans = scans.filter((scan) => String(scan.status || '') !== 'failed');
         const scores = completedScans
           .map((scan) => {

--- a/frontend/src/pages/TodayPage.tsx
+++ b/frontend/src/pages/TodayPage.tsx
@@ -159,7 +159,7 @@ const TodayPage: React.FC = () => {
     const loadData = async () => {
       try {
         const historyData = await getScanHistory();
-        const scans = (historyData as { scans?: Array<Record<string, unknown>> }).scans || [];
+        const scans = (historyData as Record<string, unknown>).data as Array<Record<string, unknown>> || (historyData as Record<string, unknown>).scans as Array<Record<string, unknown>> || [];
         const statusStr = (s: Record<string, unknown>) => String(s.status ?? '').toLowerCase();
         const completed = scans.filter((s) => statusStr(s) === 'completed');
         const scores = completed


### PR DESCRIPTION
Sprint 2 changed scan history endpoint from {scans: [...]} to {data: [...], next_cursor, has_more}. Updated all frontend consumers to check .data first, fallback to .scans for backwards compatibility.

Fixed: ScanContext, DashboardPage, MePage, HistoryPage, ComparisonPage, AnalysisResults, ProfileSettingsPage, TodayPage, DataExportPage

https://claude.ai/code/session_016XpCGMkdoVXBdD3E6dHejV

### Summary

- **What**: One-line summary of the change
- **Why**: Short justification and links to SRS/backlog

### Changes

- Files and modules changed (example: `backend/app/services/auth_service.py`)

### How to run / test locally

```bash
cd backend
pytest -q
```

### Checklist

- [ ] Tests added or updated
- [ ] Documentation updated (`docs/PROJECT_PROGRESS_TRACKER.md` or relevant doc)
- [ ] Env changes documented (`backend/.env.example`)
- [ ] DB migrations added (if schema changes)

### Notes for reviewers

- Any important notes about the change, deployment steps, or potential impacts
