### PR TITLE
fix: chat crash + add page headers to new pages

### DIFF
--- a/frontend/src/pages/AdminAnalyticsPage.tsx
+++ b/frontend/src/pages/AdminAnalyticsPage.tsx
@@ -64,12 +64,13 @@ const AdminAnalyticsPage: React.FC = () => {
 
   return (
     <div className={styles.page}>
+      <header className="app-header-card">
+        <h1>Admin Analytics</h1>
+        <p className="app-header-subtitle">Platform performance and usage metrics</p>
+      </header>
       <div className={styles.container}>
         <header className={styles.header}>
-          <div>
-            <h1 className={styles.title}>Analytics</h1>
-            <p className={styles.subtitle}>Platform performance and usage metrics.</p>
-          </div>
+          <div></div>
           <div className={styles.rangeTabs}>
             {(['7d', '30d', '90d'] as DateRange[]).map((range) => (
               <button

--- a/frontend/src/pages/ClinicalDashboardPage.tsx
+++ b/frontend/src/pages/ClinicalDashboardPage.tsx
@@ -80,16 +80,16 @@ const ClinicalDashboardPage: React.FC = () => {
 
   return (
     <div className={styles.page}>
+      <header className="app-header-card">
+        <h1>Clinical Dashboard</h1>
+        <p className="app-header-subtitle">Monitor your skin health metrics and clinical insights</p>
+      </header>
+
       <AlertBanner alerts={activeAlerts} onDismiss={handleDismiss} />
 
       <div className={styles.container}>
         <header className={styles.header}>
-          <div>
-            <h1 className={styles.title}>Clinical Dashboard</h1>
-            <p className={styles.subtitle}>
-              Monitor your skin health metrics and clinical insights.
-            </p>
-          </div>
+          <div></div>
           <button
             className={styles.generateBtn}
             onClick={handleGenerateReport}

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -191,6 +191,12 @@ const SearchPage: React.FC = () => {
 
   return (
     <div className={styles.page}>
+      {/* Page Header */}
+      <header className="app-header-card">
+        <h1>Search</h1>
+        <p className="app-header-subtitle">Search products, ingredients, and articles</p>
+      </header>
+
       {/* Search Bar */}
       <div className={styles.searchBarWrapper} ref={typeaheadRef}>
         <div className={styles.searchInputContainer}>

--- a/frontend/src/services/chatApi.ts
+++ b/frontend/src/services/chatApi.ts
@@ -50,7 +50,9 @@ export async function listSessions(): Promise<ChatSession[]> {
     const err = await res.json().catch(() => ({ detail: 'Failed to list sessions' }));
     throw new Error(err.detail || 'Failed to list sessions');
   }
-  return res.json();
+  const json = await res.json();
+  // Backend returns paginated envelope {data: [...]} or plain array
+  return Array.isArray(json) ? json : (json.data || []);
 }
 
 export async function getMessages(sessionId: number | string): Promise<ChatMessage[]> {
@@ -62,7 +64,8 @@ export async function getMessages(sessionId: number | string): Promise<ChatMessa
     const err = await res.json().catch(() => ({ detail: 'Failed to get messages' }));
     throw new Error(err.detail || 'Failed to get messages');
   }
-  return res.json();
+  const json = await res.json();
+  return Array.isArray(json) ? json : (json.data || []);
 }
 
 export async function deleteSession(sessionId: number | string): Promise<void> {


### PR DESCRIPTION
1. Chat crash: listSessions/getMessages returned paginated envelope {data:[...]} but code expected plain array. Now extracts .data
2. SearchPage: added blue header banner (app-header-card)
3. ClinicalDashboardPage: added blue header banner
4. AdminAnalyticsPage: added blue header banner

These 3 pages were unstyled because they lacked the standard app-header-card that every other page uses.

https://claude.ai/code/session_016XpCGMkdoVXBdD3E6dHejV

### Summary

- **What**: One-line summary of the change
- **Why**: Short justification and links to SRS/backlog

### Changes

- Files and modules changed (example: `backend/app/services/auth_service.py`)

### How to run / test locally

```bash
cd backend
pytest -q
```

### Checklist

- [ ] Tests added or updated
- [ ] Documentation updated (`docs/PROJECT_PROGRESS_TRACKER.md` or relevant doc)
- [ ] Env changes documented (`backend/.env.example`)
- [ ] DB migrations added (if schema changes)

### Notes for reviewers

- Any important notes about the change, deployment steps, or potential impacts
