### PR TITLE
fix: homepage star ratings + reduce nav clutter

### DIFF
--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -208,14 +208,9 @@ const displayName = nameParts.length > 1
               <Link className={`app-nav-link${location.pathname === '/' ? ' active' : ''}`} to="/" aria-current={location.pathname === '/' ? 'page' : undefined} onMouseEnter={() => { void import('../pages/HomePage'); }}>Home</Link>
               <Link className={`app-nav-link${location.pathname.startsWith('/scan') ? ' active' : ''}`} to="/scan" title="Scan face or product" aria-current={location.pathname.startsWith('/scan') ? 'page' : undefined} onMouseEnter={() => void import('../pages/ScanPage')}>Scan</Link>
               <Link className={`app-nav-link${location.pathname.startsWith('/dashboard') ? ' active' : ''}`} to="/dashboard" title="View your dashboard and insights" aria-current={location.pathname.startsWith('/dashboard') ? 'page' : undefined} onMouseEnter={() => void import('../pages/DashboardPage')}>Dashboard</Link>
-              <Link className={`app-nav-link${location.pathname.startsWith('/digital-twin') ? ' active' : ''}`} to="/digital-twin" aria-current={location.pathname.startsWith('/digital-twin') ? 'page' : undefined} onMouseEnter={() => { void import('../pages/DigitalTwinTimelinePage'); }}>Digital Twin</Link>
               {isAuthenticated && (
                 <Link className={`app-nav-link${location.pathname.startsWith('/chat') ? ' active' : ''}`} to="/chat" title="AI Skincare Assistant" aria-current={location.pathname.startsWith('/chat') ? 'page' : undefined} onMouseEnter={() => { void import('../pages/AIChatPage'); }}>AI Chat</Link>
               )}
-              {isAuthenticated && (
-                <Link className={`app-nav-link${location.pathname.startsWith('/clinical') ? ' active' : ''}`} to="/clinical" title="Clinical Intelligence Dashboard" aria-current={location.pathname.startsWith('/clinical') ? 'page' : undefined} onMouseEnter={() => { void import('../pages/ClinicalDashboardPage'); }}>Clinical</Link>
-              )}
-              <Link className={`app-nav-link${location.pathname.startsWith('/search') ? ' active' : ''}`} to="/search" title="Search products, ingredients, articles" aria-current={location.pathname.startsWith('/search') ? 'page' : undefined} onMouseEnter={() => { void import('../pages/SearchPage'); }}>Search</Link>
               <Link className={`app-nav-link${location.pathname.startsWith('/about') ? ' active' : ''}`} to="/about" aria-current={location.pathname.startsWith('/about') ? 'page' : undefined} onMouseEnter={() => { void import('../pages/AboutPage'); }}>About</Link>
               {isAuthenticated && user?.is_admin && (
                 <Link className={`app-nav-link${location.pathname.startsWith('/admin') ? ' active' : ''}`} to="/admin" aria-current={location.pathname.startsWith('/admin') ? 'page' : undefined} onMouseEnter={() => { void import('../pages/AdminDashboardPage'); }}>Admin</Link>

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -430,7 +430,7 @@ const HomePage: React.FC = () => {
             </div>
             <div className="testimonial-stars">
               {Array.from({ length: 5 }).map((_, index) => (
-                <IconStar key={index} size={16} strokeWidth={2} />
+                <IconStar key={index} size={16} strokeWidth={2} fill="#f59e0b" stroke="#f59e0b" />
               ))}
             </div>
             <p>
@@ -450,7 +450,7 @@ const HomePage: React.FC = () => {
             </div>
             <div className="testimonial-stars">
               {Array.from({ length: 5 }).map((_, index) => (
-                <IconStar key={index} size={16} strokeWidth={2} />
+                <IconStar key={index} size={16} strokeWidth={2} fill="#f59e0b" stroke="#f59e0b" />
               ))}
             </div>
             <p>
@@ -470,7 +470,7 @@ const HomePage: React.FC = () => {
             </div>
             <div className="testimonial-stars">
               {Array.from({ length: 5 }).map((_, index) => (
-                <IconStar key={index} size={16} strokeWidth={2} />
+                <IconStar key={index} size={16} strokeWidth={2} fill="#f59e0b" stroke="#f59e0b" />
               ))}
             </div>
             <p>


### PR DESCRIPTION
Critical homepage fixes from UX audit:
1. Testimonial stars: added fill="#f59e0b" stroke="#f59e0b" to all IconStar components — were rendering as empty outlines (0 stars)
2. Nav reduced from 8 items to 5: removed Digital Twin, Clinical, Search from top nav (accessible via Dashboard/mobile menu). Keeps: Home, Scan, Dashboard, AI Chat, About

https://claude.ai/code/session_016XpCGMkdoVXBdD3E6dHejV

### Summary

- **What**: One-line summary of the change
- **Why**: Short justification and links to SRS/backlog

### Changes

- Files and modules changed (example: `backend/app/services/auth_service.py`)

### How to run / test locally

```bash
cd backend
pytest -q
```

### Checklist

- [ ] Tests added or updated
- [ ] Documentation updated (`docs/PROJECT_PROGRESS_TRACKER.md` or relevant doc)
- [ ] Env changes documented (`backend/.env.example`)
- [ ] DB migrations added (if schema changes)

### Notes for reviewers

- Any important notes about the change, deployment steps, or potential impacts
