### PR TITLE
revert: restore homepage to original design

### DIFF
--- a/frontend/src/pages/HomePage.css
+++ b/frontend/src/pages/HomePage.css
@@ -1,10 +1,11 @@
 /* ==========================================================================
-   HomePage.css — Pellicura 2026 Redesign
-   Gradient mesh hero, glassmorphism, bento grid, animated score rings
+   HomePage.css — Pellicura Landing Page
+   Clean rewrite: ~1,000 lines replacing 3,350.
+   Organized: Base → Sections (top-to-bottom) → Animations → Responsive
    ========================================================================== */
 
 /* ==========================================================================
-   1. BASE
+   1. BASE & PAGE RESET
    ========================================================================== */
 
 .homepage {
@@ -14,7 +15,7 @@
 }
 
 /* ==========================================================================
-   2. FADE-IN ANIMATION
+   2. FADE-IN ANIMATION WRAPPER
    ========================================================================== */
 
 .fade-in-section {
@@ -33,22 +34,42 @@
    3. SHARED SECTION RHYTHM
    ========================================================================== */
 
+.trust-badges-section,
+.as-featured-section,
+.stats-section,
+.results-preview,
+.how-it-works,
+.testimonials-section,
+.faq-section,
+.cta-section {
+  padding: var(--section-padding-y) var(--section-padding-x);
+}
+
+/* Alternating backgrounds for visual separation */
+.trust-badges-section { background: var(--bg-secondary); }
+.as-featured-section  { background: var(--bg-primary); }
+.stats-section        { background: var(--bg-secondary); }
+.results-preview      { background: var(--bg-primary); }
+.how-it-works         { background: var(--bg-secondary); }
+.testimonials-section { background: var(--bg-primary); }
+.faq-section          { background: var(--bg-secondary); }
+
+/* Shared section headers */
 .section-header {
   text-align: center;
-  margin-bottom: 40px;
+  margin-bottom: var(--section-header-gap);
 }
 
 .section-header h2 {
-  font-size: clamp(1.5rem, 3.5vw, 2.25rem);
-  font-weight: 800;
+  font-size: var(--font-size-3xl);
+  font-weight: var(--font-weight-bold);
   color: var(--text-primary);
   margin: 0 0 8px;
   line-height: 1.2;
-  letter-spacing: -0.02em;
 }
 
 .section-header p {
-  font-size: 1rem;
+  font-size: var(--font-size-base, 1rem);
   color: var(--text-secondary);
   margin: 0;
   max-width: 520px;
@@ -58,10 +79,10 @@
 
 .section-tag {
   display: inline-block;
-  font-size: 0.7rem;
-  font-weight: 700;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
   text-transform: uppercase;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.08em;
   color: var(--primary);
   background: rgba(var(--primary-rgb), 0.08);
   padding: 4px 14px;
@@ -70,87 +91,106 @@
 }
 
 /* ==========================================================================
-   4. HERO — 2026 GRADIENT MESH + GLASSMORPHISM
+   4. HERO SECTION
    ========================================================================== */
 
-.hero-2026 {
+.hero {
   position: relative;
-  min-height: 90vh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 80px var(--spacing-lg, 24px) 60px;
-  overflow: hidden;
-}
-
-/* Gradient mesh background */
-.hero-mesh-bg {
-  position: absolute;
-  inset: 0;
-  background:
-    radial-gradient(ellipse 80% 60% at 20% 40%, rgba(var(--primary-rgb), 0.08) 0%, transparent 70%),
-    radial-gradient(ellipse 60% 80% at 80% 20%, rgba(var(--accent-rgb), 0.06) 0%, transparent 70%),
-    radial-gradient(ellipse 50% 50% at 50% 80%, rgba(139, 92, 246, 0.04) 0%, transparent 60%),
-    linear-gradient(180deg, var(--bg-primary) 0%, var(--bg-secondary) 100%);
-  z-index: 0;
-}
-
-.hero-inner {
-  position: relative;
-  z-index: 1;
   display: grid;
   grid-template-columns: 1.1fr 0.9fr;
   align-items: center;
-  gap: 56px;
+  gap: 48px;
   max-width: 1200px;
-  width: 100%;
+  margin: 0 auto;
+  padding: 48px var(--section-padding-x) 40px;
+  min-height: auto;
 }
 
-/* --- Hero Left: Text --- */
-.hero-text-col {
+/* Decorative background blobs */
+.hero-decoration {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+  z-index: 0;
+}
+
+.hero-blob {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(80px);
+  opacity: 0.6;
+}
+
+.hero-blob--1 {
+  width: 500px;
+  height: 500px;
+  background: rgba(var(--primary-rgb), 0.12);
+  top: -15%;
+  right: -10%;
+  animation: blobFloat 18s ease-in-out infinite;
+}
+
+.hero-blob--2 {
+  width: 350px;
+  height: 350px;
+  background: rgba(var(--accent-rgb), 0.10);
+  bottom: -10%;
+  left: -5%;
+  animation: blobFloat 22s ease-in-out infinite reverse;
+}
+
+.hero-blob--3 {
+  width: 250px;
+  height: 250px;
+  background: rgba(var(--primary-rgb), 0.08);
+  top: 30%;
+  left: 40%;
+  animation: blobFloat 15s ease-in-out infinite 3s;
+}
+
+/* Hero text content */
+.hero-content {
+  position: relative;
+  z-index: 1;
+}
+
+.hero-text {
   display: flex;
   flex-direction: column;
   gap: 20px;
 }
 
-.hero-badge-2026 {
+.hero-badge {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  font-size: 0.8rem;
-  font-weight: 600;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
   color: var(--primary);
-  background: rgba(var(--primary-rgb), 0.06);
-  border: 1px solid rgba(var(--primary-rgb), 0.12);
+  background: rgba(var(--primary-rgb), 0.08);
   padding: 6px 16px;
   border-radius: 24px;
   width: fit-content;
 }
 
-.hero-badge-dot {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: var(--primary);
-  animation: pulse-dot 2s ease-in-out infinite;
+.badge-icon {
+  display: flex;
+  align-items: center;
+  color: var(--primary);
 }
 
-@keyframes pulse-dot {
-  0%, 100% { opacity: 1; transform: scale(1); }
-  50% { opacity: 0.5; transform: scale(1.3); }
-}
-
-.hero-title-2026 {
-  font-size: clamp(2.25rem, 4.5vw, 3.75rem);
+.hero-title {
+  font-size: clamp(2rem, 4vw, 3.5rem);
   font-weight: 800;
-  line-height: 1.08;
+  line-height: 1.1;
   color: var(--text-primary);
   margin: 0;
-  letter-spacing: -0.03em;
+  letter-spacing: -0.02em;
 }
 
-.hero-gradient-text {
-  background: linear-gradient(135deg, var(--primary) 0%, #7c3aed 50%, var(--accent) 100%);
+.gradient-text {
+  background: linear-gradient(135deg, var(--primary) 0%, var(--accent) 50%, var(--primary-dark) 100%);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
@@ -158,22 +198,29 @@
   animation: gradientShift 8s ease infinite;
 }
 
-.hero-subtitle-2026 {
-  font-size: clamp(1rem, 1.5vw, 1.125rem);
+.hero-subtitle {
+  font-size: clamp(1rem, 1.5vw, 1.15rem);
   color: var(--text-secondary);
-  line-height: 1.65;
+  line-height: 1.6;
   margin: 0;
-  max-width: 500px;
+  max-width: 480px;
 }
 
-.hero-actions {
+.hero-cta {
   display: flex;
   align-items: center;
   gap: 14px;
   flex-wrap: wrap;
 }
 
-.hero-btn-primary {
+.hero-cta .btn {
+  min-height: 48px;
+  font-weight: 600;
+  border-radius: var(--radius-xl);
+  cursor: pointer;
+}
+
+.btn-primary--hero {
   display: inline-flex;
   align-items: center;
   gap: 8px;
@@ -182,154 +229,140 @@
   border: none;
   padding: 14px 28px;
   font-size: 1rem;
-  font-weight: 600;
-  border-radius: 14px;
-  cursor: pointer;
-  box-shadow: 0 8px 24px -6px rgba(var(--primary-rgb), 0.35);
-  transition: transform 0.2s, box-shadow 0.2s;
-  min-height: 48px;
+  box-shadow: var(--shadow-primary);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.hero-btn-primary:hover {
+.btn-primary--hero:hover {
   transform: translateY(-2px);
-  box-shadow: 0 14px 32px -8px rgba(var(--primary-rgb), 0.4);
+  box-shadow: 0 12px 24px -8px rgba(var(--primary-rgb), 0.4);
 }
 
-.hero-btn-secondary {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  border: 1.5px solid var(--border-color);
-  color: var(--text-primary);
-  background: rgba(255, 255, 255, 0.6);
-  backdrop-filter: blur(8px);
-  padding: 14px 24px;
-  font-size: 1rem;
-  font-weight: 600;
-  border-radius: 14px;
-  cursor: pointer;
-  transition: background 0.2s, border-color 0.2s;
-  min-height: 48px;
-}
-
-.hero-btn-secondary:hover {
-  background: rgba(var(--primary-rgb), 0.04);
-  border-color: rgba(var(--primary-rgb), 0.2);
-}
-
-.hero-trust-row {
+.btn-icon {
   display: flex;
   align-items: center;
-  gap: 12px;
-  flex-wrap: wrap;
 }
 
-.hero-trust-row span {
-  display: inline-flex;
+.hero-cta-secondary {
+  border: 1.5px solid var(--border-color);
+  color: var(--primary);
+  background: transparent;
+  padding: 14px 24px;
+  font-size: 1rem;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.hero-cta-secondary:hover {
+  background: rgba(var(--primary-rgb), 0.05);
+  border-color: rgba(var(--primary-rgb), 0.3);
+}
+
+.hero-reassurance {
+  display: flex;
   align-items: center;
-  gap: 5px;
-  font-size: 0.8rem;
+  gap: 6px;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
+  margin: 0;
 }
 
-.hero-trust-sep {
-  width: 3px;
-  height: 3px;
-  border-radius: 50%;
-  background: var(--text-muted);
-  opacity: 0.4;
+.inline-icon {
+  flex-shrink: 0;
+  vertical-align: middle;
 }
 
-/* --- Hero Right: Glass Card --- */
-.hero-visual-col {
+/* Hero visual — sample report card */
+.hero-visual {
+  position: relative;
+  z-index: 1;
   display: flex;
   justify-content: center;
 }
 
-.hero-card-glass {
-  background: rgba(255, 255, 255, 0.72);
-  backdrop-filter: blur(24px) saturate(1.4);
-  -webkit-backdrop-filter: blur(24px) saturate(1.4);
-  border: 1px solid rgba(255, 255, 255, 0.5);
-  border-radius: 24px;
-  padding: 28px;
+.sample-report-preview {
+  background: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-xl);
+  padding: 28px 24px;
+  box-shadow: var(--shadow-xl);
   width: 100%;
-  max-width: 360px;
-  box-shadow:
-    0 20px 60px -20px rgba(0, 0, 0, 0.1),
-    0 0 0 1px rgba(255, 255, 255, 0.3) inset;
+  max-width: 340px;
   animation: cardFloat 6s ease-in-out infinite;
 }
 
-.hero-card-header {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 0.8rem;
-  font-weight: 600;
-  color: var(--text-secondary);
+.preview-header {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
+  color: var(--text-primary);
+  text-align: center;
   margin-bottom: 20px;
-  padding-bottom: 14px;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--border-color);
 }
 
-.hero-card-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-}
-
-.hero-card-dot--live {
-  background: #22c55e;
-  box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.2);
-  animation: pulse-dot 2s ease-in-out infinite;
-}
-
-.hero-card-scores {
+.preview-scores {
   display: flex;
   justify-content: space-around;
   margin-bottom: 20px;
 }
 
-.score-ring-item {
+.score-item {
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 6px;
 }
 
-.score-ring-label {
-  font-size: 0.7rem;
+.score-item span {
+  font-size: var(--font-size-xs);
   color: var(--text-secondary);
-  font-weight: 600;
+  font-weight: var(--font-weight-medium);
 }
 
-.hero-card-concerns {
+.score-circle {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
   display: flex;
-  gap: 6px;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.125rem;
+  font-weight: 800;
+  color: white;
+}
+
+.score-circle.good {
+  background: linear-gradient(135deg, #22c55e, #16a34a);
+}
+
+.score-circle.medium {
+  background: linear-gradient(135deg, #f59e0b, #d97706);
+}
+
+.preview-concerns {
+  display: flex;
+  gap: 8px;
   justify-content: center;
   flex-wrap: wrap;
-  margin-bottom: 16px;
+  margin-bottom: 14px;
 }
 
-.hero-concern-pill {
+.concern-badge {
+  font-size: var(--font-size-xs);
+  padding: 4px 12px;
+  background: rgba(var(--primary-rgb), 0.08);
+  color: var(--primary);
+  border-radius: 20px;
+  font-weight: var(--font-weight-medium);
+}
+
+.preview-disclaimer {
   font-size: 0.7rem;
-  padding: 4px 10px;
-  background: rgba(239, 68, 68, 0.08);
-  color: #dc2626;
-  border-radius: 16px;
-  font-weight: 600;
-}
-
-.hero-concern-pill--good {
-  background: rgba(34, 197, 94, 0.08);
-  color: #16a34a;
-}
-
-.hero-card-footer {
-  font-size: 0.65rem;
   color: var(--text-muted);
   text-align: center;
+  margin: 0;
   line-height: 1.4;
 }
 
@@ -351,111 +384,134 @@
 }
 
 /* ==========================================================================
-   5. TRUST BAR — Horizontal with descriptions
+   5. TRUST BADGES SECTION
    ========================================================================== */
 
-.trust-bar-section {
-  padding: 0 var(--spacing-lg, 24px);
-  margin-top: -32px;
-  position: relative;
-  z-index: 2;
-}
-
-.trust-bar {
+.trust-badges-grid {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: 16px;
+  gap: 20px;
   max-width: 1100px;
   margin: 0 auto;
 }
 
-.trust-bar-item {
+.trust-badge-card {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 14px;
-  padding: 20px 18px;
-  background: rgba(255, 255, 255, 0.85);
+  gap: 12px;
+  padding: 24px 16px;
+  background: rgba(255, 255, 255, 0.6);
   backdrop-filter: blur(16px);
   -webkit-backdrop-filter: blur(16px);
-  border: 1px solid rgba(0, 0, 0, 0.06);
-  border-radius: 16px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.04);
-  transition: transform 0.25s ease, box-shadow 0.25s ease;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-xl);
+  text-align: center;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
 }
 
-.trust-bar-item:hover {
-  transform: translateY(-3px);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.07);
+.trust-badge-card:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-lg);
 }
 
-.trust-bar-icon {
+.trust-badge-icon {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 44px;
-  height: 44px;
-  border-radius: 12px;
-  flex-shrink: 0;
+  width: 52px;
+  height: 52px;
+  border-radius: var(--radius-lg);
+  font-size: 1.5rem;
 }
 
-.trust-bar-icon--green  { background: rgba(34, 197, 94, 0.1); color: #16a34a; }
-.trust-bar-icon--blue   { background: rgba(var(--primary-rgb), 0.1); color: var(--primary); }
-.trust-bar-icon--purple { background: rgba(139, 92, 246, 0.1); color: #7c3aed; }
-.trust-bar-icon--teal   { background: rgba(20, 184, 166, 0.1); color: #0d9488; }
-
-.trust-bar-content {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  min-width: 0;
+/* Distinct icon colors per badge type */
+.trust-badge-privacy .trust-badge-icon {
+  background: rgba(34, 197, 94, 0.1);
+  color: #16a34a;
 }
 
-.trust-bar-title {
-  font-size: 0.8rem;
-  font-weight: 700;
+.trust-badge-security .trust-badge-icon {
+  background: rgba(var(--primary-rgb), 0.1);
+  color: var(--primary);
+}
+
+.trust-badge-research .trust-badge-icon {
+  background: rgba(139, 92, 246, 0.1);
+  color: #7c3aed;
+}
+
+.trust-badge-delete .trust-badge-icon {
+  background: rgba(239, 68, 68, 0.1);
+  color: #dc2626;
+}
+
+.trust-badge-text {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   color: var(--text-primary);
 }
 
-.trust-bar-desc {
-  font-size: 0.7rem;
+/* ==========================================================================
+   6. AS FEATURED SECTION
+   ========================================================================== */
+
+.as-featured-section {
+  text-align: center;
+}
+
+.as-featured-label {
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
   color: var(--text-muted);
-  line-height: 1.35;
+  margin: 0 0 16px;
+  font-weight: var(--font-weight-medium);
+}
+
+.as-featured-logos {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 24px 40px;
+  flex-wrap: wrap;
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.as-featured-badge {
+  display: inline-block;
+  padding: 8px 20px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
+  color: var(--text-secondary);
 }
 
 /* ==========================================================================
-   6. STATS — Clean dividers
+   7. STATS SECTION
    ========================================================================== */
 
-.stats-section-2026 {
-  padding: 48px var(--spacing-lg, 24px);
-}
-
-.stats-inner {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0;
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--spacing-xl);
   max-width: 900px;
   margin: 0 auto;
-  background: rgba(255, 255, 255, 0.7);
-  backdrop-filter: blur(12px);
-  border: 1px solid rgba(0, 0, 0, 0.04);
-  border-radius: 20px;
-  padding: 32px 16px;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.03);
+  text-align: center;
 }
 
-.stat-card {
-  flex: 1;
+.stat-item {
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 4px;
-  text-align: center;
 }
 
 .stat-number {
-  font-size: clamp(1.75rem, 4vw, 2.75rem);
+  font-size: var(--font-size-5xl);
   font-weight: 800;
   background: var(--gradient-primary);
   -webkit-background-clip: text;
@@ -465,323 +521,268 @@
 }
 
 .stat-label {
-  font-size: 0.8rem;
+  font-size: var(--font-size-sm);
   color: var(--text-secondary);
-  font-weight: 500;
-}
-
-.stat-divider {
-  width: 1px;
-  height: 48px;
-  background: var(--border-color);
-  opacity: 0.5;
-  flex-shrink: 0;
+  font-weight: var(--font-weight-medium);
 }
 
 /* ==========================================================================
-   7. BENTO FEATURE GRID
+   8. RESULTS PREVIEW SECTION
    ========================================================================== */
 
-.bento-section {
-  padding: 64px var(--spacing-lg, 24px);
-  background: var(--bg-secondary);
-}
-
-.bento-grid {
+.results-grid {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-template-rows: auto auto;
-  gap: 20px;
-  max-width: 1100px;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 24px;
+  max-width: 1200px;
   margin: 0 auto;
 }
 
-/* Large card spans full width of left column */
-.bento-card {
-  background: rgba(255, 255, 255, 0.9);
-  border: 1px solid var(--border-color);
-  border-radius: 20px;
-  padding: 32px 28px;
-  transition: transform 0.25s ease, box-shadow 0.25s ease;
-  position: relative;
-  overflow: hidden;
-}
-
-.bento-card:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.06);
-}
-
-.bento-card--large {
-  grid-row: 1 / 3;
-}
-
-.bento-card-icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 56px;
-  height: 56px;
-  border-radius: 16px;
-  margin-bottom: 16px;
-}
-
-.bento-card--scores .bento-card-icon { background: rgba(59, 130, 246, 0.08); color: #3b82f6; }
-.bento-card--concern .bento-card-icon { background: rgba(239, 68, 68, 0.08); color: #ef4444; }
-.bento-card--routine .bento-card-icon { background: rgba(139, 92, 246, 0.08); color: #7c3aed; }
-.bento-card--tracking .bento-card-icon { background: rgba(34, 197, 94, 0.08); color: #22c55e; }
-
-.bento-card h3 {
-  font-size: 1.1rem;
-  font-weight: 700;
-  color: var(--text-primary);
-  margin: 0 0 8px;
-}
-
-.bento-card p {
-  font-size: 0.875rem;
-  color: var(--text-secondary);
-  line-height: 1.6;
-  margin: 0;
-}
-
-/* Mini score bars inside the large card */
-.bento-mini-scores {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  margin-top: 24px;
-}
-
-.bento-mini-bar {
-  position: relative;
-  height: 8px;
-  background: rgba(0, 0, 0, 0.04);
-  border-radius: 4px;
-  overflow: hidden;
-}
-
-.bento-mini-bar span {
-  display: block;
-  height: 100%;
-  border-radius: 4px;
-  transition: width 1.2s cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-.bento-mini-bar label {
-  position: absolute;
-  right: 0;
-  top: -20px;
-  font-size: 0.7rem;
-  font-weight: 600;
-  color: var(--text-secondary);
-}
-
-.bento-badge-free {
-  display: inline-block;
-  font-size: 0.65rem;
-  font-weight: 600;
-  color: var(--primary);
-  background: rgba(var(--primary-rgb), 0.06);
-  padding: 3px 10px;
-  border-radius: 12px;
-  margin-top: 12px;
-}
-
-/* ==========================================================================
-   8. HOW IT WORKS — Timeline
-   ========================================================================== */
-
-.how-it-works-2026 {
-  padding: 64px var(--spacing-lg, 24px);
-  background: var(--bg-primary);
-}
-
-.steps-timeline {
-  display: flex;
-  justify-content: center;
-  gap: 0;
-  max-width: 1000px;
-  margin: 0 auto;
-  position: relative;
-}
-
-.step-2026 {
-  flex: 1;
+.result-card {
   display: flex;
   flex-direction: column;
   align-items: center;
   text-align: center;
-  position: relative;
-  padding: 0 20px;
+  padding: 32px 24px;
+  background: rgba(255, 255, 255, 0.8);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-xl);
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
 }
 
-.step-number-2026 {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 44px;
-  height: 44px;
-  border-radius: 50%;
-  background: var(--gradient-primary);
-  color: white;
-  font-size: 1.1rem;
-  font-weight: 800;
-  margin-bottom: 20px;
-  position: relative;
-  z-index: 2;
-  box-shadow: 0 4px 12px rgba(var(--primary-rgb), 0.25);
+.result-card:hover {
+  transform: translateY(-6px);
+  box-shadow: var(--shadow-lg);
+  border-color: rgba(var(--primary-rgb), 0.2);
 }
 
-.step-connector {
-  position: absolute;
-  top: 22px;
-  left: calc(50% + 30px);
-  width: calc(100% - 60px);
-  height: 2px;
-  background: linear-gradient(90deg, var(--primary), rgba(var(--primary-rgb), 0.2));
-  z-index: 1;
-}
-
-.step-content-2026 {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 8px;
-}
-
-.step-visual-2026 {
-  margin-bottom: 8px;
-}
-
-.step-icon-box {
+.result-icon {
   display: flex;
   align-items: center;
   justify-content: center;
   width: 72px;
   height: 72px;
-  border-radius: 20px;
+  border-radius: 18px;
+  background: rgba(var(--primary-rgb), 0.08);
+  color: var(--primary);
+  margin-bottom: 16px;
 }
 
-.step-icon-box--blue   { background: rgba(var(--primary-rgb), 0.08); color: var(--primary); }
-.step-icon-box--purple { background: rgba(139, 92, 246, 0.08); color: #7c3aed; }
-.step-icon-box--green  { background: rgba(34, 197, 94, 0.08); color: #22c55e; }
-
-.step-content-2026 h3 {
+.result-card h3 {
   font-size: 1.05rem;
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
   color: var(--text-primary);
-  margin: 0;
+  margin: 0 0 8px;
 }
 
-.step-content-2026 p {
-  font-size: 0.85rem;
+.result-card p {
+  font-size: var(--font-size-sm);
   color: var(--text-secondary);
   line-height: 1.55;
   margin: 0;
-  max-width: 260px;
 }
 
-.step-tips-2026 {
-  display: flex;
-  gap: 12px;
-  flex-wrap: wrap;
-  justify-content: center;
-  margin-top: 6px;
-}
-
-.step-tips-2026 span {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  font-size: 0.7rem;
-  color: #16a34a;
-  font-weight: 600;
+.account-note {
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  font-style: italic;
 }
 
 /* ==========================================================================
-   9. TESTIMONIALS — Horizontal scroll on mobile, grid on desktop
+   9. HOW IT WORKS SECTION
    ========================================================================== */
 
-.testimonials-section-2026 {
-  padding: 64px var(--spacing-lg, 24px);
-  background: var(--bg-secondary);
-}
-
-.testimonials-scroll {
+.steps-container {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 20px;
+  gap: 28px;
   max-width: 1100px;
   margin: 0 auto;
 }
 
-.testimonial-card-2026 {
-  background: rgba(255, 255, 255, 0.9);
-  border: 1px solid var(--border-color);
-  border-radius: 20px;
-  padding: 28px;
-  transition: transform 0.25s ease, box-shadow 0.25s ease;
+.step-card {
   position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 32px 24px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 22px;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
 }
 
-.testimonial-card-2026:hover {
+.step-card:hover {
   transform: translateY(-4px);
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.06);
+  box-shadow: var(--shadow-lg);
+}
+
+/* Chevron connectors between steps (desktop only) */
+.step-card:not(:last-child)::after {
+  content: '';
+  position: absolute;
+  right: -18px;
+  top: 48px;
+  width: 8px;
+  height: 8px;
+  border-top: 2px solid rgba(var(--primary-rgb), 0.35);
+  border-right: 2px solid rgba(var(--primary-rgb), 0.35);
+  transform: rotate(45deg);
+  z-index: 2;
+}
+
+.step-number {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: var(--gradient-primary);
+  color: white;
+  font-size: 1.25rem;
+  font-weight: 800;
+  margin-bottom: 16px;
+  flex-shrink: 0;
+}
+
+.step-illustration {
+  width: 100%;
+  max-width: 200px;
+  margin-bottom: 16px;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.step-illustration img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.step-illustration--primary { background: rgba(var(--primary-rgb), 0.06); }
+.step-illustration--accent  { background: rgba(var(--accent-rgb), 0.06); }
+.step-illustration--soft    { background: rgba(var(--primary-rgb), 0.04); }
+
+.step-card h3 {
+  font-size: 1.1rem;
+  font-weight: var(--font-weight-bold);
+  color: var(--text-primary);
+  margin: 0 0 8px;
+}
+
+.step-card p {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  line-height: 1.55;
+  margin: 0;
+}
+
+.step-tips {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: 14px;
+}
+
+.step-tips span {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: var(--font-size-xs);
+  color: var(--text-secondary);
+  font-weight: var(--font-weight-medium);
+}
+
+.step-tips .inline-icon {
+  color: #16a34a;
+}
+
+/* ==========================================================================
+   10. TESTIMONIALS SECTION
+   ========================================================================== */
+
+.testimonials-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.testimonial-card {
+  position: relative;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-xl);
+  padding: 28px;
+  overflow: hidden;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.testimonial-card:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-lg);
 }
 
 /* Quotation watermark */
-.testimonial-card-2026::after {
+.testimonial-card::after {
   content: '\201C';
   position: absolute;
   top: 8px;
-  right: 18px;
+  right: 16px;
   font-size: 4rem;
   line-height: 1;
-  color: rgba(var(--primary-rgb), 0.05);
+  color: rgba(var(--primary-rgb), 0.06);
   font-family: Georgia, serif;
   pointer-events: none;
 }
 
-.testimonial-top {
+.testimonial-header {
   display: flex;
   align-items: center;
   gap: 12px;
   margin-bottom: 12px;
 }
 
-.testimonial-avatar-2026 {
+.testimonial-avatar {
   width: 42px;
   height: 42px;
   border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 0.85rem;
-  font-weight: 700;
+  overflow: hidden;
   flex-shrink: 0;
 }
 
-.testimonial-top h4 {
-  font-size: 0.875rem;
-  font-weight: 700;
+.testimonial-avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.testimonial-header h3 {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
   color: var(--text-primary);
   margin: 0;
 }
 
-.testimonial-tag {
-  font-size: 0.7rem;
+.testimonial-header span {
+  font-size: var(--font-size-xs);
   color: var(--text-muted);
+  display: block;
 }
 
-.testimonial-stars-2026 {
+.testimonial-stars {
   display: flex;
   gap: 2px;
   margin-bottom: 12px;
+  color: #fbbf24;
 }
 
-.testimonial-card-2026 > p {
-  font-size: 0.85rem;
+.testimonial-card p {
+  font-size: var(--font-size-sm);
   color: var(--text-secondary);
   line-height: 1.65;
   font-style: italic;
@@ -789,34 +790,29 @@
 }
 
 /* ==========================================================================
-   10. FAQ — Centered
+   11. FAQ SECTION
    ========================================================================== */
-
-.faq-section-2026 {
-  padding: 64px var(--spacing-lg, 24px);
-  background: var(--bg-primary);
-}
 
 .faq-container {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 12px;
   max-width: 720px;
   margin: 0 auto;
 }
 
 .faq-item {
-  background: var(--bg-secondary);
+  background: var(--bg-primary);
   border: 1px solid var(--border-color);
-  border-radius: 14px;
+  border-radius: var(--radius-lg);
   padding: 0;
+  box-shadow: var(--shadow-sm);
   overflow: hidden;
   transition: border-color 0.2s ease;
 }
 
 .faq-item--open {
-  border-color: rgba(var(--primary-rgb), 0.2);
-  background: rgba(var(--primary-rgb), 0.02);
+  border-left: 3px solid var(--primary);
 }
 
 .faq-summary {
@@ -824,9 +820,9 @@
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  padding: 18px 22px;
-  font-size: 0.9rem;
-  font-weight: 600;
+  padding: 20px 24px;
+  font-size: 0.95rem;
+  font-weight: var(--font-weight-bold);
   color: var(--text-primary);
   background: none;
   border: none;
@@ -842,8 +838,8 @@
 
 .faq-chevron {
   display: inline-block;
-  width: 9px;
-  height: 9px;
+  width: 10px;
+  height: 10px;
   border-right: 2px solid var(--text-muted);
   border-bottom: 2px solid var(--text-muted);
   transform: rotate(45deg);
@@ -867,94 +863,100 @@
 }
 
 .faq-answer p {
-  padding: 0 22px 18px;
-  font-size: 0.85rem;
+  padding: 0 24px 20px;
+  font-size: var(--font-size-sm);
   color: var(--text-secondary);
   line-height: 1.65;
   margin: 0;
 }
 
 /* ==========================================================================
-   11. FINAL CTA — Gradient with filled button
+   12. CTA SECTION
    ========================================================================== */
 
-.cta-section-2026 {
-  padding: 80px var(--spacing-lg, 24px);
+.cta-section {
   background: var(--gradient-primary);
   position: relative;
   overflow: hidden;
 }
 
-.cta-section-2026::before {
+/* Subtle radial highlight overlay */
+.cta-section::before {
   content: '';
   position: absolute;
   inset: 0;
-  background:
-    radial-gradient(ellipse at 30% 50%, rgba(255, 255, 255, 0.08) 0%, transparent 60%),
-    radial-gradient(ellipse at 80% 30%, rgba(255, 255, 255, 0.06) 0%, transparent 50%);
+  background: radial-gradient(ellipse at 50% 0%, rgba(255, 255, 255, 0.1) 0%, transparent 70%);
   pointer-events: none;
 }
 
-.cta-inner-2026 {
+.cta-content {
   position: relative;
-  max-width: 600px;
+  max-width: 640px;
   margin: 0 auto;
   text-align: center;
   z-index: 1;
 }
 
-.cta-inner-2026 h2 {
-  font-size: clamp(1.5rem, 3.5vw, 2.25rem);
+.cta-content h2 {
+  font-size: var(--font-size-4xl);
   font-weight: 800;
   color: white;
   margin: 0 0 12px;
   line-height: 1.15;
 }
 
-.cta-inner-2026 > p {
-  font-size: 1rem;
+.cta-content > p {
+  font-size: 1.05rem;
   color: rgba(255, 255, 255, 0.85);
   margin: 0 0 28px;
 }
 
-.cta-btn-2026 {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
+.btn-cta-hero {
+  display: inline-block;
   background: white;
   color: var(--primary);
-  font-size: 1rem;
-  font-weight: 700;
-  padding: 16px 36px;
+  font-size: 1.05rem;
+  font-weight: var(--font-weight-bold);
+  padding: 16px 40px;
   border: none;
-  border-radius: 14px;
+  border-radius: var(--radius-lg);
   cursor: pointer;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.15);
-  transition: transform 0.2s, box-shadow 0.2s;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.cta-btn-2026:hover {
+.btn-cta-hero:hover {
   transform: translateY(-2px);
   box-shadow: 0 14px 36px rgba(0, 0, 0, 0.2);
 }
 
-.cta-reassurance-2026 {
+.cta-reassurance {
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 6px;
-  font-size: 0.8rem;
-  color: rgba(255, 255, 255, 0.65);
-  margin-top: 16px;
+  font-size: var(--font-size-sm);
+  color: rgba(255, 255, 255, 0.7);
+  margin: 16px 0 0;
+}
+
+.icon-inline {
+  flex-shrink: 0;
 }
 
 /* ==========================================================================
-   12. KEYFRAMES
+   13. KEYFRAME ANIMATIONS
    ========================================================================== */
 
 @keyframes gradientShift {
   0%, 100% { background-position: 0% 50%; }
   50% { background-position: 100% 50%; }
+}
+
+@keyframes blobFloat {
+  0%, 100% { transform: translate(0, 0) scale(1); }
+  33% { transform: translate(20px, -15px) scale(1.04); }
+  66% { transform: translate(-10px, 10px) scale(0.97); }
 }
 
 @keyframes cardFloat {
@@ -968,73 +970,61 @@
 }
 
 /* ==========================================================================
-   13. RESPONSIVE: TABLET (<=1024px)
+   14. RESPONSIVE: TABLET (≤1024px)
    ========================================================================== */
 
 @media (max-width: 1024px) {
-  .hero-2026 {
-    min-height: auto;
-    padding: 60px var(--spacing-lg, 24px) 48px;
-  }
-
-  .hero-inner {
+  .hero {
     grid-template-columns: 1fr;
     gap: 40px;
+    padding: 60px var(--section-padding-x) 48px;
+    min-height: auto;
     text-align: center;
   }
 
-  .hero-text-col {
+  .hero-text {
     align-items: center;
   }
 
-  .hero-subtitle-2026 {
+  .hero-subtitle {
     max-width: 500px;
     margin-inline: auto;
   }
 
-  .hero-actions {
+  .hero-cta {
     justify-content: center;
   }
 
-  .hero-trust-row {
+  .hero-reassurance {
     justify-content: center;
   }
 
-  .hero-visual-col {
+  .hero-visual {
     justify-content: center;
   }
 
-  .hero-card-glass {
-    max-width: 320px;
+  .sample-report-preview {
+    max-width: 300px;
   }
 
-  .trust-bar-section {
-    margin-top: -16px;
-  }
-
-  .trust-bar {
+  .trust-badges-grid {
     grid-template-columns: repeat(2, 1fr);
   }
 
-  .bento-grid {
+  .results-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .steps-container {
     grid-template-columns: 1fr;
-  }
-
-  .bento-card--large {
-    grid-row: auto;
-  }
-
-  .steps-timeline {
-    flex-direction: column;
-    gap: 32px;
     max-width: 480px;
   }
 
-  .step-connector {
+  .step-card:not(:last-child)::after {
     display: none;
   }
 
-  .testimonials-scroll {
+  .testimonials-grid {
     grid-template-columns: 1fr;
     max-width: 500px;
     margin-inline: auto;
@@ -1042,180 +1032,119 @@
 }
 
 /* ==========================================================================
-   14. RESPONSIVE: MOBILE (<=768px)
+   15. RESPONSIVE: MOBILE (≤768px)
    ========================================================================== */
 
 @media (max-width: 768px) {
-  .hero-2026 {
-    padding: 40px 16px 36px;
+  .hero {
+    padding: 40px var(--section-padding-x) 36px;
+    gap: 32px;
   }
 
-  .hero-title-2026 {
-    font-size: clamp(1.75rem, 7vw, 2.25rem);
+  .hero-title {
+    font-size: clamp(1.75rem, 6vw, 2.25rem);
   }
 
-  .hero-actions {
+  .hero-cta {
     flex-direction: column;
     width: 100%;
   }
 
-  .hero-btn-primary,
-  .hero-btn-secondary {
+  .hero-cta .btn {
     width: 100%;
     justify-content: center;
     text-align: center;
   }
 
-  .hero-card-glass {
+  .sample-report-preview {
     max-width: 280px;
-    padding: 20px;
+    transform: scale(0.9);
   }
 
   .scroll-indicator {
     display: none;
   }
 
-  .trust-bar {
-    grid-template-columns: 1fr;
-    gap: 10px;
+  .stats-grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--spacing-lg);
   }
 
-  .trust-bar-item {
-    padding: 14px 16px;
-  }
-
-  .stats-inner {
-    flex-wrap: wrap;
-    padding: 24px 12px;
-    border-radius: 16px;
-  }
-
-  .stat-card {
-    flex: 0 0 calc(50% - 1px);
-    padding: 12px 0;
-  }
-
-  .stat-divider {
-    display: none;
-  }
-
-  .bento-section,
-  .how-it-works-2026,
-  .testimonials-section-2026,
-  .faq-section-2026 {
-    padding: 40px 16px;
+  .stat-number {
+    font-size: var(--font-size-4xl);
   }
 
   .section-header h2 {
-    font-size: 1.35rem;
+    font-size: var(--font-size-xl, 1.5rem);
   }
 
-  .cta-section-2026 {
-    padding: 56px 16px;
+  .cta-content h2 {
+    font-size: var(--font-size-3xl);
   }
 
-  .cta-btn-2026 {
+  .btn-cta-hero {
     width: 100%;
-    justify-content: center;
+    text-align: center;
   }
 
   .faq-summary {
-    padding: 14px 16px;
-    font-size: 0.825rem;
+    padding: 16px 18px;
+    font-size: var(--font-size-sm);
   }
 
   .faq-answer p {
-    padding: 0 16px 14px;
+    padding: 0 18px 16px;
   }
 }
 
 /* ==========================================================================
-   15. RESPONSIVE: SMALL (<=480px)
+   16. RESPONSIVE: SMALL (≤480px)
    ========================================================================== */
 
 @media (max-width: 480px) {
-  .hero-2026 {
-    padding: 28px 12px 24px;
+  .hero {
+    padding: 28px 16px 24px;
   }
 
-  .hero-card-glass {
-    max-width: 260px;
-    padding: 18px;
+  .hero-blob--1 { width: 300px; height: 300px; }
+  .hero-blob--2 { width: 200px; height: 200px; }
+  .hero-blob--3 { display: none; }
+
+  .trust-badges-grid {
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
   }
 
-  .trust-bar-item {
-    gap: 10px;
-    padding: 12px 14px;
+  .trust-badge-card {
+    padding: 16px 12px;
   }
 
-  .bento-card {
-    padding: 24px 20px;
+  .results-grid {
+    grid-template-columns: 1fr;
   }
 
-  .testimonial-card-2026 {
+  .stat-item {
+    background: rgba(255, 255, 255, 0.8);
+    border-radius: var(--radius-lg);
+    padding: 16px 8px;
+  }
+
+  .as-featured-logos {
+    gap: 12px 20px;
+  }
+
+  .as-featured-badge {
+    padding: 6px 14px;
+    font-size: var(--font-size-xs);
+  }
+
+  .step-card {
+    padding: 24px 18px;
+  }
+
+  .testimonial-card {
     padding: 20px;
   }
-
-  .step-2026 {
-    padding: 0 8px;
-  }
-}
-
-/* ==========================================================================
-   16. DARK MODE OVERRIDES
-   ========================================================================== */
-
-[data-theme="dark"] .hero-card-glass {
-  background: rgba(30, 41, 59, 0.8);
-  border-color: rgba(255, 255, 255, 0.08);
-  box-shadow: 0 20px 60px -20px rgba(0, 0, 0, 0.5);
-}
-
-[data-theme="dark"] .hero-card-header {
-  border-bottom-color: rgba(255, 255, 255, 0.06);
-}
-
-[data-theme="dark"] .trust-bar-item {
-  background: rgba(30, 41, 59, 0.85);
-  border-color: rgba(255, 255, 255, 0.06);
-}
-
-[data-theme="dark"] .stats-inner {
-  background: rgba(30, 41, 59, 0.7);
-  border-color: rgba(255, 255, 255, 0.04);
-}
-
-[data-theme="dark"] .bento-card {
-  background: rgba(30, 41, 59, 0.7);
-}
-
-[data-theme="dark"] .testimonial-card-2026 {
-  background: rgba(30, 41, 59, 0.7);
-}
-
-[data-theme="dark"] .faq-item {
-  background: rgba(30, 41, 59, 0.5);
-}
-
-[data-theme="dark"] .hero-btn-secondary {
-  background: rgba(30, 41, 59, 0.6);
-  color: var(--text-primary);
-}
-
-[data-theme="dark"] .hero-mesh-bg {
-  background:
-    radial-gradient(ellipse 80% 60% at 20% 40%, rgba(129, 140, 248, 0.08) 0%, transparent 70%),
-    radial-gradient(ellipse 60% 80% at 80% 20%, rgba(79, 138, 217, 0.06) 0%, transparent 70%),
-    radial-gradient(ellipse 50% 50% at 50% 80%, rgba(139, 92, 246, 0.04) 0%, transparent 60%),
-    linear-gradient(180deg, var(--bg-primary) 0%, var(--bg-secondary) 100%);
-}
-
-[data-theme="dark"] .score-ring-item svg circle:first-child {
-  stroke: rgba(255, 255, 255, 0.08);
-}
-
-[data-theme="dark"] .bento-mini-bar {
-  background: rgba(255, 255, 255, 0.06);
 }
 
 /* ==========================================================================
@@ -1229,13 +1158,15 @@
     transition: none;
   }
 
-  .hero-gradient-text,
-  .hero-badge-dot,
-  .hero-card-dot--live {
+  .gradient-text {
     animation: none;
   }
 
-  .hero-card-glass {
+  .hero-blob {
+    animation: none;
+  }
+
+  .sample-report-preview {
     animation: none;
   }
 
@@ -1243,12 +1174,12 @@
     animation: none;
   }
 
-  .trust-bar-item,
-  .bento-card,
-  .testimonial-card-2026,
-  .hero-btn-primary,
-  .hero-btn-secondary,
-  .cta-btn-2026 {
+  .trust-badge-card,
+  .result-card,
+  .step-card,
+  .testimonial-card,
+  .btn-primary--hero,
+  .btn-cta-hero {
     transition: none;
   }
 }

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -4,7 +4,7 @@ import { usePageTitle } from '../hooks/usePageTitle';
 import {
   IconZap, IconScan, IconClock, IconShield, IconBookOpen,
   IconBarChart, IconSearch, IconSparkles, IconTrendingUp,
-  IconCheck, IconStar, IconLock, IconTrash2
+  IconCheck, IconStar
 } from '../components/Icons';
 import './HomePage.css';
 
@@ -58,19 +58,21 @@ const FadeInSection: React.FC<FadeInSectionProps> = ({ children, className = '',
 const AnimatedCounter: React.FC<{
   end: number; suffix?: string; prefix?: string; duration?: number; decimal?: boolean;
 }> = ({ end, suffix = '', prefix = '', duration = 1200, decimal = false }) => {
+  // Start at final value so the page never shows 0 or bad numbers
   const [count, setCount] = useState(end);
   const [hasAnimated, setHasAnimated] = useState(false);
   const ref = useRef<HTMLSpanElement>(null);
 
   useEffect(() => {
     const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-    if (prefersReduced) return;
+    if (prefersReduced) return; // Already showing end value
     const el = ref.current;
     if (!el) return;
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting && !hasAnimated) {
           setHasAnimated(true);
+          // Animate from 80% of the target to 100% — subtle, never shows bad numbers
           const start = Math.round(end * 0.8);
           setCount(start);
           const startTime = performance.now();
@@ -98,46 +100,6 @@ const AnimatedCounter: React.FC<{
     <span ref={ref} className="stat-number stat-number--animated">
       {prefix}{displayValue}{suffix}
     </span>
-  );
-};
-
-/** Animated score ring for the hero card */
-const ScoreRing: React.FC<{ score: number; label: string; color: string; delay?: number }> = ({ score, label, color, delay = 0 }) => {
-  const [animated, setAnimated] = useState(false);
-  const ref = useRef<SVGCircleElement>(null);
-  const circumference = 2 * Math.PI * 26;
-  const offset = circumference - (score / 100) * circumference;
-
-  useEffect(() => {
-    const timer = setTimeout(() => setAnimated(true), delay + 300);
-    return () => clearTimeout(timer);
-  }, [delay]);
-
-  return (
-    <div className="score-ring-item">
-      <svg width="68" height="68" viewBox="0 0 60 60">
-        <circle cx="30" cy="30" r="26" fill="none" stroke="rgba(0,0,0,0.06)" strokeWidth="5" />
-        <circle
-          ref={ref}
-          cx="30" cy="30" r="26"
-          fill="none"
-          stroke={color}
-          strokeWidth="5"
-          strokeLinecap="round"
-          strokeDasharray={circumference}
-          strokeDashoffset={animated ? offset : circumference}
-          style={{
-            transition: 'stroke-dashoffset 1.2s cubic-bezier(0.4, 0, 0.2, 1)',
-            transform: 'rotate(-90deg)',
-            transformOrigin: 'center',
-          }}
-        />
-        <text x="30" y="33" textAnchor="middle" fontSize="15" fontWeight="800" fill={color}>
-          {score}
-        </text>
-      </svg>
-      <span className="score-ring-label">{label}</span>
-    </div>
   );
 };
 
@@ -208,311 +170,340 @@ const FaqAccordion: React.FC = () => {
 const HomePage: React.FC = () => {
   usePageTitle(null);
   const navigate = useNavigate();
+  const avatarBase = (initials: string, color: string) =>
+    `data:image/svg+xml;utf8,${encodeURIComponent(
+      `<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96">
+        <defs>
+          <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stop-color="${color}" stop-opacity="0.15"/>
+            <stop offset="100%" stop-color="${color}" stop-opacity="0.35"/>
+          </linearGradient>
+        </defs>
+        <rect width="96" height="96" rx="48" fill="url(#g)"/>
+        <text x="50%" y="54%" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="28" fill="${color}" font-weight="700">
+          ${initials}
+        </text>
+      </svg>`
+    )}`;
 
   return (
     <div className="homepage">
-      {/* ===================== HERO SECTION ===================== */}
-      <section className="hero-2026">
-        <div className="hero-mesh-bg" aria-hidden="true" />
-        <div className="hero-inner">
-          <div className="hero-text-col">
-            <div className="hero-badge-2026">
-              <span className="hero-badge-dot" />
-              AI-Powered Skin Analysis
+      {/* Hero Section - Updated with safer claims */}
+      <FadeInSection className="hero">
+        <div className="hero-decoration" aria-hidden="true">
+          <span className="hero-blob hero-blob--1" />
+          <span className="hero-blob hero-blob--2" />
+          <span className="hero-blob hero-blob--3" />
+        </div>
+        <div className="hero-content">
+          <div className="hero-text">
+            <div className="hero-badge">
+              <span className="badge-icon">
+                <IconZap size={20} strokeWidth={2} />
+              </span>
+              Clinical Skin Insights
             </div>
-            <h1 className="hero-title-2026">
-              Understand Your Skin<br />
-              <span className="hero-gradient-text">In Under 60 Seconds</span>
+            <h1 className="hero-title">
+              AI Skin Assessment<br />
+              <span className="gradient-text">From a Single Photo</span>
             </h1>
-            <p className="hero-subtitle-2026">
-              Upload a photo and receive a detailed skin health assessment with
-              personalized care recommendations — powered by clinical-grade AI.
+            <p className="hero-subtitle">
+              Receive clear skin-quality insights and practical care recommendations in under a minute.
             </p>
-            <div className="hero-actions">
-              <button type="button" className="hero-btn-primary" onClick={() => navigate('/scan')}>
-                <IconScan size={20} strokeWidth={2} />
-                Start Free Analysis
+            <div className="hero-cta">
+              <button type="button" className="btn btn-primary btn-primary--hero" onClick={() => navigate('/scan')}>
+                <span className="btn-icon">
+                  <IconScan size={20} strokeWidth={2} />
+                </span>
+                Start Free Skin Scan
               </button>
-              <button type="button" className="hero-btn-secondary" onClick={() => navigate('/analysis/demo')}>
-                View Sample Report
+              <button type="button" className="btn btn-ghost hero-cta-secondary" onClick={() => navigate('/analysis/demo')}>
+                See Sample Report
               </button>
             </div>
-            <div className="hero-trust-row">
-              <span><IconClock size={14} /> ~30 sec analysis</span>
-              <span className="hero-trust-sep" aria-hidden="true" />
-              <span><IconShield size={14} /> No signup required</span>
-              <span className="hero-trust-sep" aria-hidden="true" />
-              <span><IconTrash2 size={14} /> Delete anytime</span>
-            </div>
+            <p className="hero-reassurance">
+              <IconClock size={16} strokeWidth={2} className="inline-icon" />
+              Takes ~30 seconds &bull; No signup required &bull; Delete your photo anytime
+            </p>
+            {/* Learn more link removed — all sections now visible on mobile */}
           </div>
-
-          <div className="hero-visual-col">
-            <div className="hero-card-glass">
-              <div className="hero-card-header">
-                <span className="hero-card-dot hero-card-dot--live" />
-                Live Analysis Preview
+        </div>
+        <div className="hero-visual">
+          <div className="sample-report-preview">
+            <div className="preview-header">Sample Analysis Result</div>
+            <div className="preview-scores">
+              <div className="score-item">
+                <div className="score-circle good">85</div>
+                <span>Overall</span>
               </div>
-              <div className="hero-card-scores">
-                <ScoreRing score={85} label="Overall" color="#22c55e" delay={0} />
-                <ScoreRing score={72} label="Texture" color="#f59e0b" delay={200} />
-                <ScoreRing score={88} label="Hydration" color="#3b82f6" delay={400} />
+              <div className="score-item">
+                <div className="score-circle medium">72</div>
+                <span>Texture</span>
               </div>
-              <div className="hero-card-concerns">
-                <span className="hero-concern-pill">Mild Acne</span>
-                <span className="hero-concern-pill">Slight Redness</span>
-                <span className="hero-concern-pill hero-concern-pill--good">Good Elasticity</span>
-              </div>
-              <div className="hero-card-footer">
-                AI confidence: High &middot; Based on visible features
+              <div className="score-item">
+                <div className="score-circle good">88</div>
+                <span>Hydration</span>
               </div>
             </div>
+            <div className="preview-concerns">
+              <span className="concern-badge">Mild Acne</span>
+              <span className="concern-badge">Slight Redness</span>
+            </div>
+              <p className="preview-disclaimer">Results are estimates based on visible features and image quality.</p>
           </div>
         </div>
         <ScrollIndicator />
-      </section>
+      </FadeInSection>
 
-      {/* ===================== TRUST BAR ===================== */}
-      <FadeInSection className="trust-bar-section">
-        <div className="trust-bar">
-          <div className="trust-bar-item">
-            <div className="trust-bar-icon trust-bar-icon--green">
-              <IconShield size={22} strokeWidth={2.5} />
-            </div>
-            <div className="trust-bar-content">
-              <span className="trust-bar-title">GDPR Compliant</span>
-              <span className="trust-bar-desc">Your data is protected under EU privacy law</span>
-            </div>
+      {/* Trust Badges - Privacy first, then Encrypted, Research, Delete */}
+      <FadeInSection className="trust-badges-section">
+        <div className="trust-badges-grid">
+          <div className="trust-badge-card trust-badge-privacy">
+            <span className="trust-badge-icon">
+              <IconShield size={28} strokeWidth={2.5} fill="currentColor" />
+            </span>
+            <span className="trust-badge-text">Privacy-First Processing</span>
           </div>
-          <div className="trust-bar-item">
-            <div className="trust-bar-icon trust-bar-icon--blue">
-              <IconLock size={22} strokeWidth={2.5} />
-            </div>
-            <div className="trust-bar-content">
-              <span className="trust-bar-title">AES-256 Encrypted</span>
-              <span className="trust-bar-desc">Bank-grade encryption for all uploads</span>
-            </div>
+          <div className="trust-badge-card trust-badge-security">
+            <span className="trust-badge-icon">
+              <IconShield size={28} strokeWidth={2.5} fill="currentColor" />
+            </span>
+            <span className="trust-badge-text">Encrypted Uploads</span>
           </div>
-          <div className="trust-bar-item">
-            <div className="trust-bar-icon trust-bar-icon--purple">
-              <IconZap size={22} strokeWidth={2.5} />
-            </div>
-            <div className="trust-bar-content">
-              <span className="trust-bar-title">AI-Powered</span>
-              <span className="trust-bar-desc">GPT-4 Vision + dermatology models</span>
-            </div>
+          <div className="trust-badge-card trust-badge-research">
+            <span className="trust-badge-icon">
+              <IconBookOpen size={28} strokeWidth={2.5} fill="currentColor" />
+            </span>
+            <span className="trust-badge-text">Dermatology Research</span>
           </div>
-          <div className="trust-bar-item">
-            <div className="trust-bar-icon trust-bar-icon--teal">
-              <IconBookOpen size={22} strokeWidth={2.5} />
-            </div>
-            <div className="trust-bar-content">
-              <span className="trust-bar-title">Research-Backed</span>
-              <span className="trust-bar-desc">Based on peer-reviewed dermatology</span>
-            </div>
+          <div className="trust-badge-card trust-badge-delete">
+            <span className="trust-badge-icon">
+              <IconShield size={28} strokeWidth={2.5} fill="currentColor" />
+            </span>
+            <span className="trust-badge-text">Delete Data Anytime</span>
           </div>
         </div>
       </FadeInSection>
 
-      {/* ===================== STATS ===================== */}
-      <FadeInSection className="stats-section-2026">
-        <div className="stats-inner">
-          <div className="stat-card">
+      {/* Trust / Compliance badges (replacing unverifiable press mentions) */}
+      <FadeInSection className="as-featured-section" aria-label="Built with trust">
+        <p className="as-featured-label">Built with clinical standards</p>
+        <div className="as-featured-logos" role="list">
+          <span className="as-featured-badge" role="listitem">GDPR Compliant</span>
+          <span className="as-featured-badge" role="listitem">AI-Powered Analysis</span>
+          <span className="as-featured-badge" role="listitem">Dermatology Research</span>
+          <span className="as-featured-badge" role="listitem">AES-256 Encrypted</span>
+        </div>
+      </FadeInSection>
+
+      {/* Community Stats */}
+      <FadeInSection className="stats-section">
+        <div className="section-header">
+          <span className="section-tag">Trusted Platform</span>
+          <h2>Join Thousands of Skincare Enthusiasts</h2>
+          <p>Real results from real users improving their skin health</p>
+        </div>
+        <div className="stats-grid">
+          <div className="stat-item">
             <AnimatedCounter end={50000} suffix="+" />
             <span className="stat-label">Scans Completed</span>
           </div>
-          <div className="stat-divider" />
-          <div className="stat-card">
+          <div className="stat-item">
             <AnimatedCounter end={12000} suffix="+" />
             <span className="stat-label">Active Users</span>
           </div>
-          <div className="stat-divider" />
-          <div className="stat-card">
+          <div className="stat-item">
             <AnimatedCounter end={48} suffix="/5" decimal />
             <span className="stat-label">User Rating</span>
           </div>
-          <div className="stat-divider" />
-          <div className="stat-card">
+          <div className="stat-item">
             <AnimatedCounter end={95} suffix="%" />
-            <span className="stat-label">Satisfaction</span>
+            <span className="stat-label">Satisfaction Rate</span>
           </div>
         </div>
       </FadeInSection>
 
-      {/* ===================== BENTO FEATURES ===================== */}
-      <FadeInSection className="bento-section">
+      {/* What You'll Get Section - NEW */}
+      <FadeInSection className="results-preview">
         <div className="section-header">
-          <span className="section-tag">What You Get</span>
-          <h2>Comprehensive Skin Intelligence</h2>
-          <p>Everything you need to understand and improve your skin health</p>
+          <span className="section-tag">Your Results</span>
+          <h2>What You'll Get</h2>
+          <p>Comprehensive skin analysis with actionable insights</p>
         </div>
-        <div className="bento-grid">
-          <div className="bento-card bento-card--large bento-card--scores">
-            <div className="bento-card-icon">
-              <IconBarChart size={32} strokeWidth={1.5} />
+        <div className="results-grid">
+          <div className="result-card">
+            <div className="result-icon">
+              <IconBarChart size={48} strokeWidth={2} />
             </div>
-            <h3>Detailed Skin Scores</h3>
-            <p>Overall health, texture, hydration, and clarity rated 0-100 with trend tracking over time</p>
-            <div className="bento-mini-scores">
-              <div className="bento-mini-bar"><span style={{ width: '85%', background: '#22c55e' }} /><label>Overall 85</label></div>
-              <div className="bento-mini-bar"><span style={{ width: '72%', background: '#f59e0b' }} /><label>Texture 72</label></div>
-              <div className="bento-mini-bar"><span style={{ width: '88%', background: '#3b82f6' }} /><label>Hydration 88</label></div>
-            </div>
+            <h3>Skin Scores</h3>
+            <p>Overall health, texture, hydration, and clarity scores from 0-100</p>
           </div>
-          <div className="bento-card bento-card--concern">
-            <div className="bento-card-icon">
-              <IconSearch size={28} strokeWidth={1.5} />
+          <div className="result-card">
+            <div className="result-icon">
+              <IconSearch size={48} strokeWidth={2} />
             </div>
             <h3>Concern Detection</h3>
             <p>Identifies visible signs of acne, redness, pigmentation, and fine lines</p>
           </div>
-          <div className="bento-card bento-card--routine">
-            <div className="bento-card-icon">
-              <IconSparkles size={28} strokeWidth={1.5} />
+          <div className="result-card">
+            <div className="result-icon">
+              <IconSparkles size={48} strokeWidth={2} />
             </div>
-            <h3>Smart Routines</h3>
-            <p>Personalized AM/PM routines with product recommendations</p>
+            <h3>Routine Suggestions</h3>
+            <p>Personalized AM/PM skincare routine recommendations</p>
           </div>
-          <div className="bento-card bento-card--tracking">
-            <div className="bento-card-icon">
-              <IconTrendingUp size={28} strokeWidth={1.5} />
+          <div className="result-card">
+            <div className="result-icon">
+              <IconTrendingUp size={48} strokeWidth={2} />
             </div>
             <h3>Progress Tracking</h3>
-            <p>Compare scans over time and see your skin improve</p>
-            <span className="bento-badge-free">Free account</span>
+                        <p>Track improvements over time with scan history comparisons <span className="account-note">(Optional – requires account)</span></p>
           </div>
         </div>
       </FadeInSection>
 
-      {/* ===================== HOW IT WORKS ===================== */}
-      <FadeInSection className="how-it-works-2026">
+      {/* How It Works - Updated with guidance */}
+      <FadeInSection className="how-it-works">
         <div className="section-header">
-          <span className="section-tag">3 Simple Steps</span>
+          <span className="section-tag">Simple Process</span>
           <h2>How It Works</h2>
-          <p>From photo to personalized insights in under a minute</p>
+          <p>Get your personalized skin analysis in three easy steps</p>
         </div>
-        <div className="steps-timeline">
-          <div className="step-2026">
-            <div className="step-number-2026">1</div>
-            <div className="step-connector" aria-hidden="true" />
-            <div className="step-content-2026">
-              <div className="step-visual-2026">
-                <div className="step-icon-box step-icon-box--blue">
-                  <IconScan size={36} strokeWidth={1.5} />
-                </div>
-              </div>
-              <h3>Upload Your Photo</h3>
-              <p>Take a clear selfie or upload an existing photo</p>
-              <div className="step-tips-2026">
-                <span><IconCheck size={14} /> Good lighting</span>
-                <span><IconCheck size={14} /> No makeup</span>
-                <span><IconCheck size={14} /> Front-facing</span>
-              </div>
+        <div className="steps-container">
+          <div className="step-card">
+            <div className="step-number">1</div>
+            <div className="step-illustration step-illustration--primary" aria-hidden="true">
+              <img src="/how-it-works-upload.svg" alt="Upload your photo for skin analysis" loading="lazy" width="200" height="160" onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
+            </div>
+            <h3>Upload Photo</h3>
+            <p>Take or upload a clear selfie</p>
+            <div className="step-tips">
+              <span>
+                <IconCheck size={16} strokeWidth={2} className="inline-icon" />
+                Good lighting
+              </span>
+              <span>
+                <IconCheck size={16} strokeWidth={2} className="inline-icon" />
+                No makeup
+              </span>
+              <span>
+                <IconCheck size={16} strokeWidth={2} className="inline-icon" />
+                Front-facing
+              </span>
             </div>
           </div>
-          <div className="step-2026">
-            <div className="step-number-2026">2</div>
-            <div className="step-connector" aria-hidden="true" />
-            <div className="step-content-2026">
-              <div className="step-visual-2026">
-                <div className="step-icon-box step-icon-box--purple">
-                  <IconZap size={36} strokeWidth={1.5} />
-                </div>
-              </div>
-              <h3>AI Analysis</h3>
-              <p>Our model detects visible signs of acne, redness, pigmentation, and texture patterns</p>
+          <div className="step-card">
+            <div className="step-number">2</div>
+            <div className="step-illustration step-illustration--accent" aria-hidden="true">
+              <img src="/how-it-works-analysis.svg" alt="AI analyzes your skin" loading="lazy" width="200" height="160" onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
             </div>
+            <h3>AI Analysis</h3>
+            <p>Our model detects visible signs of acne, redness, pigmentation, and texture patterns</p>
           </div>
-          <div className="step-2026">
-            <div className="step-number-2026">3</div>
-            <div className="step-content-2026">
-              <div className="step-visual-2026">
-                <div className="step-icon-box step-icon-box--green">
-                  <IconSparkles size={36} strokeWidth={1.5} />
-                </div>
-              </div>
-              <h3>Get Your Report</h3>
-              <p>Receive scores, concern breakdowns, and personalized routine suggestions</p>
+          <div className="step-card">
+            <div className="step-number">3</div>
+            <div className="step-illustration step-illustration--soft" aria-hidden="true">
+              <img src="/how-it-works-results.svg" alt="View your personalized results" loading="lazy" width="200" height="160" onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
             </div>
+            <h3>Get Results</h3>
+            <p>Receive a skin summary, concern scores, and personalized routine suggestions</p>
           </div>
         </div>
       </FadeInSection>
 
-      {/* ===================== TESTIMONIALS ===================== */}
-      <FadeInSection className="testimonials-section-2026">
+      {/* Testimonials */}
+      <FadeInSection className="testimonials-section">
         <div className="section-header">
           <span className="section-tag">Real Results</span>
-          <h2>What Our Users Say</h2>
-          <p>See how people improved their routines with Pellicura</p>
+          <h2>Stories from Our Users</h2>
+          <p>See how people improved their routines with SkinCareAI</p>
         </div>
-        <div className="testimonials-scroll">
-          {[
-            {
-              name: 'Ananya P.',
-              initials: 'AP',
-              color: '#1f6feb',
-              tag: 'Redness control',
-              text: '"The weekly scans helped me spot patterns and adjust my routine. In six weeks, my redness score dropped and my skin felt calmer."',
-            },
-            {
-              name: 'James R.',
-              initials: 'JR',
-              color: '#0f766e',
-              tag: 'Texture improvement',
-              text: '"I finally understood which products were working. The AI flagged irritation early, and my texture score improved fast."',
-            },
-            {
-              name: 'Sarah K.',
-              initials: 'SK',
-              color: '#f97316',
-              tag: 'Hydration + glow',
-              text: '"The routine suggestions were spot on. My hydration went from low to balanced, and the before/after view kept me motivated."',
-            },
-          ].map((t, i) => (
-            <div className="testimonial-card-2026" key={i}>
-              <div className="testimonial-top">
-                <div className="testimonial-avatar-2026" style={{ background: `${t.color}15`, color: t.color }}>
-                  {t.initials}
-                </div>
-                <div>
-                  <h4>{t.name}</h4>
-                  <span className="testimonial-tag">{t.tag}</span>
-                </div>
+        <div className="testimonials-grid">
+          <div className="testimonial-card">
+            <div className="testimonial-header">
+              <div className="testimonial-avatar">
+                <img src={avatarBase('AP', '#1f6feb')} alt="Ananya P." />
               </div>
-              <div className="testimonial-stars-2026">
-                {Array.from({ length: 5 }).map((_, j) => (
-                  <IconStar key={j} size={15} strokeWidth={2} fill="#f59e0b" stroke="#f59e0b" />
-                ))}
+              <div>
+                <h3>Ananya P.</h3>
+                <span>Before/After: Redness control</span>
               </div>
-              <p>{t.text}</p>
             </div>
-          ))}
+            <div className="testimonial-stars">
+              {Array.from({ length: 5 }).map((_, index) => (
+                <IconStar key={index} size={16} strokeWidth={2} fill="#f59e0b" stroke="#f59e0b" />
+              ))}
+            </div>
+            <p>
+              “The weekly scans helped me spot patterns and adjust my routine.
+              In six weeks, my redness score dropped and my skin felt calmer.”
+            </p>
+          </div>
+          <div className="testimonial-card">
+            <div className="testimonial-header">
+              <div className="testimonial-avatar">
+                <img src={avatarBase('JR', '#0f766e')} alt="James R." />
+              </div>
+              <div>
+                <h3>James R.</h3>
+                <span>Before/After: Texture improvements</span>
+              </div>
+            </div>
+            <div className="testimonial-stars">
+              {Array.from({ length: 5 }).map((_, index) => (
+                <IconStar key={index} size={16} strokeWidth={2} fill="#f59e0b" stroke="#f59e0b" />
+              ))}
+            </div>
+            <p>
+              “I finally understood which products were working. The AI
+              flagged irritation early, and my texture score improved fast.”
+            </p>
+          </div>
+          <div className="testimonial-card">
+            <div className="testimonial-header">
+              <div className="testimonial-avatar">
+                <img src={avatarBase('SK', '#f97316')} alt="Sarah K." />
+              </div>
+              <div>
+                <h3>Sarah K.</h3>
+                <span>Before/After: Hydration + glow</span>
+              </div>
+            </div>
+            <div className="testimonial-stars">
+              {Array.from({ length: 5 }).map((_, index) => (
+                <IconStar key={index} size={16} strokeWidth={2} fill="#f59e0b" stroke="#f59e0b" />
+              ))}
+            </div>
+            <p>
+              “The routine suggestions were spot on. My hydration went from
+              low to balanced, and the before/after view kept me motivated.”
+            </p>
+          </div>
         </div>
       </FadeInSection>
 
-      {/* ===================== FAQ ===================== */}
-      <FadeInSection className="faq-section-2026">
-        <div className="section-header">
-          <span className="section-tag">Common Questions</span>
-          <h2>Frequently Asked Questions</h2>
-        </div>
-        <FaqAccordion />
-      </FadeInSection>
+        {/* FAQ Section */}
+        <FadeInSection className="faq-section">
+          <div className="section-header">
+            <span className="section-tag">Common Questions</span>
+            <h2>FAQ</h2>
+          </div>
+          <FaqAccordion />
+        </FadeInSection>
 
-      {/* ===================== FINAL CTA ===================== */}
-      <FadeInSection className="cta-section-2026">
-        <div className="cta-inner-2026">
+      {/* CTA Section - single link to avoid duplicate primary CTA (Phase 1 fix) */}
+      <FadeInSection className="cta-section">
+        <div className="cta-content">
           <h2>Ready to Understand Your Skin?</h2>
           <p>Get instant AI-powered insights from a single photo</p>
-          <button type="button" className="cta-btn-2026" onClick={() => navigate('/scan')}>
-            <IconScan size={20} strokeWidth={2} />
-            Start Free Skin Scan
-          </button>
-          <span className="cta-reassurance-2026">
-            <IconShield size={14} />
+          <button type="button" className="btn btn-cta-hero" onClick={() => navigate('/scan')}>Start Free Skin Scan</button>
+          <p className="cta-reassurance">
+            <IconShield size={16} strokeWidth={2} className="icon-inline" />
             Your photo is processed securely and never shared
-          </span>
+          </p>
         </div>
       </FadeInSection>
+      {/* Single CTA on home: hero button only (no floating CTA to avoid duplicate) */}
     </div>
   );
 };


### PR DESCRIPTION
Reverts the 2026 and medical-grade redesigns back to the working homepage with trust badges, stats, testimonials, and FAQ sections.

https://claude.ai/code/session_016XpCGMkdoVXBdD3E6dHejV

### Summary

- **What**: One-line summary of the change
- **Why**: Short justification and links to SRS/backlog

### Changes

- Files and modules changed (example: `backend/app/services/auth_service.py`)

### How to run / test locally

```bash
cd backend
pytest -q
```

### Checklist

- [ ] Tests added or updated
- [ ] Documentation updated (`docs/PROJECT_PROGRESS_TRACKER.md` or relevant doc)
- [ ] Env changes documented (`backend/.env.example`)
- [ ] DB migrations added (if schema changes)

### Notes for reviewers

- Any important notes about the change, deployment steps, or potential impacts
