### PR TITLE
feat: routine sync, scan recommendations, skin quiz, blog seed

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -269,6 +269,83 @@ def _add_missing_columns(eng) -> None:
         logger.warning("Column migration skipped: %s", exc)
 
 
+def _seed_blog_articles(eng) -> None:
+    """Seed initial blog articles if the blogs table is empty."""
+    _articles = [
+        {
+            "title": "Building a Simple Morning Skincare Routine",
+            "slug": "morning-skincare-routine",
+            "excerpt": "A step-by-step guide to creating an effective AM routine with cleansing, vitamin C, moisturizer, and SPF.",
+            "content": "<h2>Why Morning Routines Matter</h2><p>Your morning skincare routine sets the foundation for how your skin performs throughout the day. A consistent AM routine protects against UV damage, environmental pollutants, and helps maintain hydration levels.</p><h2>The 4-Step Morning Routine</h2><h3>1. Gentle Cleanser</h3><p>Start with a gentle, pH-balanced cleanser to remove overnight oil and product residue without stripping your barrier. Look for ingredients like glycerin or ceramides.</p><h3>2. Vitamin C Serum</h3><p>Apply a 10-20% L-ascorbic acid serum to brighten skin, fade dark spots, and provide antioxidant protection against free radicals.</p><h3>3. Moisturizer</h3><p>Lock in hydration with a lightweight moisturizer containing hyaluronic acid or niacinamide. Even oily skin types benefit from moisturizing.</p><h3>4. Broad-Spectrum SPF 30+</h3><p>Non-negotiable. Apply SPF as the last step of your routine, reapplying every 2 hours if exposed to direct sunlight.</p>",
+            "category": "Routines",
+            "tags": ["morning routine", "SPF", "vitamin C", "beginner"],
+            "read_time_min": 5,
+        },
+        {
+            "title": "Understanding Ingredient Interactions",
+            "slug": "ingredient-interactions",
+            "excerpt": "Learn which skincare ingredients work together and which combinations to avoid for healthier skin.",
+            "content": "<h2>Why Ingredient Pairing Matters</h2><p>Using the wrong combination of active ingredients can cause irritation, reduce effectiveness, or even damage your skin barrier. Understanding these interactions helps you build a safer, more effective routine.</p><h2>Combinations to Avoid</h2><h3>Retinol + AHA/BHA Acids</h3><p>Both are potent exfoliants. Using them together can cause excessive irritation, redness, and peeling. Use retinol at night and acids in the morning, or alternate nights.</p><h3>Vitamin C + Niacinamide (Myth!)</h3><p>Despite old advice, modern formulations of vitamin C and niacinamide work well together. This combination is actually complementary for brightening.</p><h3>Benzoyl Peroxide + Retinol</h3><p>Benzoyl peroxide can oxidize and deactivate retinol. If you use both, apply them at different times of day.</p><h2>Power Combinations</h2><ul><li><strong>Vitamin C + Vitamin E + Ferulic Acid</strong> — Enhanced antioxidant protection</li><li><strong>Hyaluronic Acid + Ceramides</strong> — Maximum hydration and barrier repair</li><li><strong>Niacinamide + Zinc</strong> — Oil control and anti-inflammatory benefits</li></ul>",
+            "category": "Ingredients",
+            "tags": ["ingredients", "retinol", "vitamin C", "acids"],
+            "read_time_min": 7,
+        },
+        {
+            "title": "How to Track Your Skin Progress with AI Scans",
+            "slug": "tracking-progress-scans",
+            "excerpt": "Consistent scanning reveals patterns your mirror can't. Learn how to get the most accurate results.",
+            "content": "<h2>Why Track Your Skin?</h2><p>Small daily changes are invisible to the naked eye. AI-powered skin analysis detects subtle shifts in hydration, texture, and pigmentation that accumulate over weeks. Tracking these changes helps you know what's working.</p><h2>Best Practices for Accurate Scans</h2><h3>Lighting</h3><p>Use consistent, diffused natural light. Avoid direct sunlight or harsh overhead lighting that creates shadows. A north-facing window provides ideal conditions.</p><h3>Timing</h3><p>Scan at the same time each session — ideally morning before applying products. Your skin's condition varies throughout the day.</p><h3>Positioning</h3><p>Keep your face centered, front-facing, at arm's length. Remove glasses, hair from face, and any makeup or sunscreen.</p><h2>How Often Should You Scan?</h2><p>Weekly scans provide the best balance of data density and meaningful change detection. Bi-weekly scans work for maintenance phases. Daily scanning adds noise without much signal.</p>",
+            "category": "Tips",
+            "tags": ["scanning", "progress", "AI", "tips"],
+            "read_time_min": 6,
+        },
+        {
+            "title": "Decoding Your Skin Type: A Complete Guide",
+            "slug": "skin-type-guide",
+            "excerpt": "Understanding whether you have oily, dry, combination, or sensitive skin is the foundation of effective skincare.",
+            "content": "<h2>The Four Main Skin Types</h2><h3>Oily Skin</h3><p>Characterized by excess sebum production, visible pores, and a shiny appearance. Oily skin is prone to breakouts but ages more slowly due to natural moisture. <strong>Key ingredients:</strong> Niacinamide, salicylic acid, lightweight moisturizers.</p><h3>Dry Skin</h3><p>Feels tight, may show flaking or rough patches. Dry skin lacks natural oils and needs rich, emollient products. <strong>Key ingredients:</strong> Ceramides, squalane, hyaluronic acid, heavy creams.</p><h3>Combination Skin</h3><p>Oily T-zone (forehead, nose, chin) with dry or normal cheeks. The most common skin type. <strong>Key ingredients:</strong> Balanced moisturizers, zone-specific treatments.</p><h3>Sensitive Skin</h3><p>Reacts easily to products, weather, and stress with redness, stinging, or irritation. <strong>Key ingredients:</strong> Centella asiatica, aloe vera, fragrance-free formulations.</p><h2>Take Our Quiz</h2><p>Not sure about your skin type? Take our <a href='/skin-quiz'>Skin Type Quiz</a> to get personalized results and product recommendations.</p>",
+            "category": "Education",
+            "tags": ["skin type", "oily", "dry", "combination", "sensitive"],
+            "read_time_min": 8,
+        },
+        {
+            "title": "The Science Behind Retinol: What You Need to Know",
+            "slug": "retinol-science",
+            "excerpt": "Retinol is the gold standard of anti-aging. Here's how it works, how to start, and what to expect.",
+            "content": "<h2>What Is Retinol?</h2><p>Retinol is a form of vitamin A that accelerates cell turnover, stimulates collagen production, and helps unclog pores. It's one of the most well-researched ingredients in dermatology with decades of clinical evidence.</p><h2>Benefits</h2><ul><li>Reduces fine lines and wrinkles</li><li>Fades hyperpigmentation and dark spots</li><li>Improves skin texture and tone</li><li>Helps prevent and treat acne</li><li>Increases collagen production</li></ul><h2>How to Start</h2><p>Begin with a low concentration (0.025-0.03%) applied 2-3 nights per week. Gradually increase frequency over 4-6 weeks as your skin builds tolerance. Always use SPF during the day when using retinol.</p><h2>Common Side Effects</h2><p>Initial purging (2-6 weeks), dryness, flaking, and sensitivity are normal. These typically resolve as your skin adjusts. If irritation persists beyond 6 weeks, reduce frequency or switch to a lower concentration.</p>",
+            "category": "Ingredients",
+            "tags": ["retinol", "anti-aging", "vitamin A", "science"],
+            "read_time_min": 6,
+        },
+    ]
+    try:
+        with eng.connect() as conn:
+            result = conn.execute(text("SELECT COUNT(*) FROM blogs"))
+            count = result.scalar() or 0
+            if count > 0:
+                return  # Already seeded
+            for article in _articles:
+                conn.execute(
+                    text(
+                        "INSERT INTO blogs (title, slug, excerpt, content, category, tags, read_time_min, published) "
+                        "VALUES (:title, :slug, :excerpt, :content, :category, :tags, :read_time_min, true)"
+                    ),
+                    {
+                        "title": article["title"],
+                        "slug": article["slug"],
+                        "excerpt": article["excerpt"],
+                        "content": article["content"],
+                        "category": article["category"],
+                        "tags": str(article["tags"]).replace("'", '"'),  # JSON format
+                        "read_time_min": article["read_time_min"],
+                    },
+                )
+            conn.commit()
+            logger.info("✅ Seeded %d blog articles", len(_articles))
+    except Exception as exc:
+        logger.warning("Blog seeding skipped: %s", exc)
+
+
 @app.on_event("startup")
 def ensure_test_user() -> None:
     """Best-effort startup bootstrap. Never crash the API process."""
@@ -285,6 +362,7 @@ def ensure_test_user() -> None:
 
         # Sprint 2+: Add new columns to existing tables if missing (safe for production)
         _add_missing_columns(engine)
+        _seed_blog_articles(engine)
     except (ProgrammingError, OperationalError) as exc:
         logger.warning("Main DB bootstrap unavailable; startup continues without seed: %s", exc)
         db_bootstrap_available = False

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -64,6 +64,7 @@ const BlogPage = React.lazy(() => import("./pages/BlogPage"));
 const BlogPostPage = React.lazy(() => import("./pages/BlogPostPage"));
 const IngredientDictionaryPage = React.lazy(() => import("./pages/IngredientDictionaryPage"));
 const SkinTypeGuidePage = React.lazy(() => import("./pages/SkinTypeGuidePage"));
+const SkinTypeQuizPage = React.lazy(() => import("./pages/SkinTypeQuizPage"));
 const VideoTutorialsPage = React.lazy(() => import("./pages/VideoTutorialsPage"));
 const DeviceContextPage = React.lazy(() => import("./pages/DeviceContextPage"));
 const AIChatPage = React.lazy(() => import("./pages/AIChatPage"));
@@ -126,6 +127,7 @@ function AppRoutes() {
           <Route path="/blog/:id" element={<BlogPostPage />} />
           <Route path="/ingredients" element={<IngredientDictionaryPage />} />
           <Route path="/skin-type-guide" element={<SkinTypeGuidePage />} />
+          <Route path="/skin-quiz" element={<SkinTypeQuizPage />} />
           <Route path="/tutorials" element={<VideoTutorialsPage />} />
           <Route path="/device-context" element={<DeviceContextPage />} />
           <Route path="/clinical" element={<ClinicalDashboardPage />} />

--- a/frontend/src/pages/AnalysisResults.tsx
+++ b/frontend/src/pages/AnalysisResults.tsx
@@ -44,6 +44,7 @@ const AnalysisResults: React.FC = () => {
   const [previousScans, setPreviousScans] = useState<ScanHistoryItem[]>([]);
   const [imageError, setImageError] = useState(false);
   const [savedToFavorites, setSavedToFavorites] = useState(false);
+  const [recProducts, setRecProducts] = useState<Array<{ id: string; name: string; brand: string; category: string; rating?: number; image_url?: string }>>([]);
   const [exporting, setExporting] = useState<'pdf' | 'image' | null>(null);
   const exportContainerRef = useRef<HTMLDivElement>(null);
   const apiBase = API_BASE_URL;
@@ -169,6 +170,37 @@ const AnalysisResults: React.FC = () => {
       setSavedToFavorites(false);
     }
   }, [analysisId]);
+
+  // Fetch product recommendations based on detected concerns
+  useEffect(() => {
+    if (!analysis || analysis.concerns.length === 0) return;
+    let cancelled = false;
+    const token = localStorage.getItem('auth_token');
+    (async () => {
+      try {
+        const url = new URL(`${API_BASE_URL}/recommendations`);
+        url.searchParams.set('concerns', analysis.concerns.join(','));
+        url.searchParams.set('limit', '3');
+        const res = await fetch(url.toString(), {
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
+        });
+        if (!res.ok || cancelled) return;
+        const data = await res.json();
+        const items = (data.recommendations || []).slice(0, 3).map((p: Record<string, unknown>) => ({
+          id: String(p.id || ''),
+          name: String(p.name || ''),
+          brand: String(p.brand || ''),
+          category: String(p.category || ''),
+          rating: typeof p.rating === 'number' ? p.rating : (typeof p.average_rating === 'number' ? p.average_rating : undefined),
+          image_url: typeof p.image_url === 'string' ? p.image_url : undefined,
+        }));
+        if (!cancelled) setRecProducts(items);
+      } catch {
+        // Non-critical
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [analysis]);
 
   const toggleSaveAnalysis = () => {
     if (!analysisId) return;
@@ -801,6 +833,38 @@ const AnalysisResults: React.FC = () => {
               </div>
             );
             })()}
+          </div>
+        )}
+
+        {/* Product Recommendations for Detected Concerns */}
+        {recProducts.length > 0 && (
+          <div className="results-section" style={{ marginTop: 24 }}>
+            <h2 className="results-section-title">
+              <IconShoppingCart size={20} strokeWidth={2} className="icon-inline" />
+              Recommended for Your Concerns
+            </h2>
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))', gap: 12 }}>
+              {recProducts.map(p => (
+                <Link
+                  key={p.id}
+                  to={`/product/${encodeURIComponent(p.id)}`}
+                  style={{
+                    display: 'flex', flexDirection: 'column', padding: 16,
+                    background: 'var(--bg-secondary, #f6f8fb)', borderRadius: 12,
+                    border: '1px solid var(--border-color, #e4e9ef)',
+                    textDecoration: 'none', color: 'inherit', transition: 'box-shadow 0.2s',
+                  }}
+                >
+                  <span style={{ fontSize: '0.7rem', fontWeight: 600, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>{p.category}</span>
+                  <span style={{ fontSize: '0.9rem', fontWeight: 700, color: 'var(--text-primary)', margin: '4px 0 2px' }}>{p.name}</span>
+                  <span style={{ fontSize: '0.8rem', color: 'var(--text-secondary)' }}>{p.brand}</span>
+                  {p.rating && <span style={{ fontSize: '0.75rem', color: 'var(--primary)', marginTop: 6 }}>Rating: {p.rating}/5</span>}
+                </Link>
+              ))}
+            </div>
+            <Link to="/recommendations" style={{ display: 'inline-block', marginTop: 12, fontSize: '0.85rem', color: 'var(--primary)', fontWeight: 600 }}>
+              View all recommendations &rarr;
+            </Link>
           </div>
         )}
 

--- a/frontend/src/pages/SkinTypeQuizPage.css
+++ b/frontend/src/pages/SkinTypeQuizPage.css
@@ -1,0 +1,48 @@
+/* Skin Type Quiz */
+.quiz-container { max-width: 600px; margin: 0 auto; }
+
+.quiz-progress { height: 4px; background: var(--bg-tertiary, #eef2f6); border-radius: 2px; margin-bottom: 8px; overflow: hidden; }
+.quiz-progress-bar { height: 100%; background: var(--primary, #1f5fbf); border-radius: 2px; transition: width 0.3s ease; }
+.quiz-step-label { font-size: 0.75rem; color: var(--text-muted); margin: 0 0 24px; }
+
+.quiz-question-card { background: var(--bg-secondary, #f6f8fb); border: 1px solid var(--border-color, #e4e9ef); border-radius: 16px; padding: 32px 28px; }
+.quiz-question { font-size: 1.1rem; font-weight: 700; color: var(--text-primary); margin: 0 0 20px; line-height: 1.35; }
+
+.quiz-options { display: flex; flex-direction: column; gap: 10px; }
+.quiz-option {
+  display: block; width: 100%; text-align: left;
+  padding: 14px 18px; font-size: 0.9rem; font-weight: 500;
+  background: var(--bg-primary, #fff); border: 1.5px solid var(--border-color, #e4e9ef);
+  border-radius: 10px; cursor: pointer; color: var(--text-primary);
+  transition: border-color 0.2s, background 0.2s;
+}
+.quiz-option:hover { border-color: var(--primary); background: rgba(var(--primary-rgb, 31,95,191), 0.03); }
+.quiz-option--selected { border-color: var(--primary); background: rgba(var(--primary-rgb, 31,95,191), 0.06); font-weight: 600; }
+
+.quiz-back { display: inline-block; margin-top: 16px; font-size: 0.8rem; color: var(--primary); background: none; border: none; cursor: pointer; padding: 0; }
+.quiz-back:hover { text-decoration: underline; }
+
+/* Result */
+.quiz-result-card { background: var(--bg-secondary, #f6f8fb); border: 1px solid var(--border-color); border-radius: 16px; padding: 32px 28px; text-align: center; }
+.quiz-result-type { margin-bottom: 16px; }
+.quiz-result-badge {
+  display: inline-block; font-size: 0.7rem; font-weight: 700; text-transform: uppercase;
+  letter-spacing: 0.1em; color: var(--primary); background: rgba(var(--primary-rgb), 0.08);
+  padding: 4px 14px; border-radius: 4px; margin-bottom: 12px;
+}
+.quiz-result-type h2 { font-size: 1.25rem; font-weight: 700; color: var(--text-primary); margin: 0; text-transform: capitalize; }
+.quiz-result-desc { font-size: 0.9rem; color: var(--text-secondary); line-height: 1.6; margin: 0 0 24px; }
+
+.quiz-result-concerns { margin-bottom: 24px; }
+.quiz-result-concerns h3 { font-size: 0.8rem; font-weight: 600; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.06em; margin: 0 0 10px; }
+.quiz-concern-tags { display: flex; gap: 8px; flex-wrap: wrap; justify-content: center; }
+.quiz-concern-tag {
+  font-size: 0.775rem; font-weight: 600; padding: 4px 12px;
+  background: rgba(var(--primary-rgb), 0.06); color: var(--primary);
+  border-radius: 16px; text-transform: capitalize;
+}
+
+.quiz-result-actions { display: flex; flex-direction: column; gap: 10px; align-items: center; }
+.quiz-result-actions .btn { min-width: 220px; }
+.quiz-retake { font-size: 0.8rem; color: var(--text-muted); background: none; border: none; cursor: pointer; margin-top: 4px; }
+.quiz-retake:hover { color: var(--primary); }

--- a/frontend/src/pages/SkinTypeQuizPage.tsx
+++ b/frontend/src/pages/SkinTypeQuizPage.tsx
@@ -1,0 +1,221 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { usePageTitle } from '../hooks/usePageTitle';
+import { useToast } from '../context/ToastContext';
+import { api } from '../services/api';
+import './SkinTypeQuizPage.css';
+
+interface QuizAnswer {
+  question: string;
+  options: string[];
+  key: string;
+}
+
+const QUIZ_QUESTIONS: QuizAnswer[] = [
+  {
+    key: 'wash_feel',
+    question: 'How does your skin feel 30 minutes after washing?',
+    options: ['Tight and dry', 'Comfortable and balanced', 'Oily, especially T-zone', 'Oily everywhere', 'Irritated or red'],
+  },
+  {
+    key: 'pore_size',
+    question: 'How would you describe your pores?',
+    options: ['Barely visible', 'Small, mostly on nose', 'Visible on nose and cheeks', 'Large and visible everywhere', 'Varies by area'],
+  },
+  {
+    key: 'midday',
+    question: 'What does your skin look like by midday?',
+    options: ['Flaky or patchy', 'Same as morning', 'Shiny T-zone, normal cheeks', 'Shiny all over', 'Red or blotchy patches'],
+  },
+  {
+    key: 'breakouts',
+    question: 'How often do you experience breakouts?',
+    options: ['Rarely', 'Occasionally around period/stress', 'Regularly on chin and forehead', 'Frequently across face', 'Breakouts with irritation/stinging'],
+  },
+  {
+    key: 'reaction',
+    question: 'How does your skin react to new products?',
+    options: ['Fine with most products', 'Occasional sensitivity', 'Breaks out if too heavy', 'No issues at all', 'Burns, stings, or turns red easily'],
+  },
+  {
+    key: 'concern',
+    question: 'What is your biggest skin concern?',
+    options: ['Dryness and flaking', 'Maintaining balance', 'Oil control and shine', 'Acne and breakouts', 'Redness and sensitivity', 'Dark spots and uneven tone', 'Fine lines and wrinkles'],
+  },
+];
+
+function determineSkinType(answers: Record<string, number>): { type: string; description: string; concerns: string[] } {
+  const { wash_feel = 0, pore_size = 0, midday = 0, breakouts = 0, reaction = 0, concern = 0 } = answers;
+
+  // Scoring heuristic
+  let dryScore = 0, oilyScore = 0, comboScore = 0, sensitiveScore = 0;
+
+  // wash_feel: 0=dry, 1=normal, 2=combo, 3=oily, 4=sensitive
+  if (wash_feel === 0) dryScore += 3;
+  if (wash_feel === 1) comboScore += 1;
+  if (wash_feel === 2) comboScore += 3;
+  if (wash_feel === 3) oilyScore += 3;
+  if (wash_feel === 4) sensitiveScore += 3;
+
+  if (pore_size <= 1) dryScore += 2;
+  if (pore_size === 2) comboScore += 2;
+  if (pore_size >= 3) oilyScore += 2;
+
+  if (midday === 0) dryScore += 2;
+  if (midday === 2) comboScore += 2;
+  if (midday === 3) oilyScore += 2;
+  if (midday === 4) sensitiveScore += 2;
+
+  if (breakouts >= 2) oilyScore += 1;
+  if (breakouts === 4) sensitiveScore += 2;
+
+  if (reaction === 4) sensitiveScore += 3;
+  if (reaction === 2) oilyScore += 1;
+
+  const scores = { dry: dryScore, oily: oilyScore, combination: comboScore, sensitive: sensitiveScore };
+  const maxType = (Object.entries(scores) as [string, number][]).sort((a, b) => b[1] - a[1])[0][0];
+
+  const concerns: string[] = [];
+  if (concern === 0) concerns.push('dryness');
+  if (concern === 2 || concern === 3) concerns.push('acne');
+  if (concern === 4) concerns.push('redness');
+  if (concern === 5) concerns.push('dark spots');
+  if (concern === 6) concerns.push('wrinkles');
+  if (breakouts >= 2) concerns.push('breakouts');
+  if (sensitiveScore >= 3) concerns.push('sensitivity');
+
+  const descriptions: Record<string, string> = {
+    dry: 'Your skin tends to feel tight and may show flaking. Focus on hydrating ingredients like hyaluronic acid and ceramides.',
+    oily: 'Your skin produces excess oil, especially in the T-zone. Look for lightweight, non-comedogenic products with niacinamide.',
+    combination: 'Your skin is oily in some areas and dry in others. Use balanced products and zone-specific treatments.',
+    sensitive: 'Your skin reacts easily to products and environment. Choose fragrance-free, gentle formulations with soothing ingredients.',
+  };
+
+  return {
+    type: maxType,
+    description: descriptions[maxType] || descriptions.combination,
+    concerns: [...new Set(concerns)].slice(0, 4),
+  };
+}
+
+const SkinTypeQuizPage: React.FC = () => {
+  usePageTitle('Skin Type Quiz');
+  const navigate = useNavigate();
+  const toast = useToast();
+  const [step, setStep] = useState(0);
+  const [answers, setAnswers] = useState<Record<string, number>>({});
+  const [result, setResult] = useState<{ type: string; description: string; concerns: string[] } | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const currentQ = QUIZ_QUESTIONS[step];
+  const totalSteps = QUIZ_QUESTIONS.length;
+  const isComplete = step >= totalSteps;
+
+  const handleSelect = (optionIndex: number) => {
+    const newAnswers = { ...answers, [currentQ.key]: optionIndex };
+    setAnswers(newAnswers);
+
+    if (step < totalSteps - 1) {
+      setStep(step + 1);
+    } else {
+      // Quiz complete — determine skin type
+      const res = determineSkinType(newAnswers);
+      setResult(res);
+      setStep(totalSteps);
+    }
+  };
+
+  const handleSaveToProfile = async () => {
+    if (!result) return;
+    setSaving(true);
+    try {
+      await api.patch('/profile', {
+        skin_type: result.type,
+        concerns: result.concerns,
+      });
+      toast.success('Skin profile updated!');
+      navigate('/dashboard');
+    } catch {
+      toast.error('Could not save. Try again.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="quiz-page app-page">
+      <header className="app-header-card">
+        <h1>Skin Type Quiz</h1>
+        <p className="app-header-subtitle">Answer {totalSteps} questions to discover your skin type</p>
+      </header>
+
+      <div className="app-page-content quiz-container">
+        {/* Progress bar */}
+        <div className="quiz-progress">
+          <div className="quiz-progress-bar" style={{ width: `${((isComplete ? totalSteps : step) / totalSteps) * 100}%` }} />
+        </div>
+        <p className="quiz-step-label">
+          {isComplete ? 'Results' : `Question ${step + 1} of ${totalSteps}`}
+        </p>
+
+        {!isComplete && currentQ && (
+          <div className="quiz-question-card">
+            <h2 className="quiz-question">{currentQ.question}</h2>
+            <div className="quiz-options">
+              {currentQ.options.map((opt, i) => (
+                <button
+                  key={i}
+                  type="button"
+                  className={`quiz-option ${answers[currentQ.key] === i ? 'quiz-option--selected' : ''}`}
+                  onClick={() => handleSelect(i)}
+                >
+                  {opt}
+                </button>
+              ))}
+            </div>
+            {step > 0 && (
+              <button type="button" className="quiz-back" onClick={() => setStep(step - 1)}>
+                &larr; Previous question
+              </button>
+            )}
+          </div>
+        )}
+
+        {isComplete && result && (
+          <div className="quiz-result-card">
+            <div className="quiz-result-type">
+              <span className="quiz-result-badge">{result.type}</span>
+              <h2>Your skin type is <strong>{result.type}</strong></h2>
+            </div>
+            <p className="quiz-result-desc">{result.description}</p>
+
+            {result.concerns.length > 0 && (
+              <div className="quiz-result-concerns">
+                <h3>Key concerns identified</h3>
+                <div className="quiz-concern-tags">
+                  {result.concerns.map(c => (
+                    <span key={c} className="quiz-concern-tag">{c}</span>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <div className="quiz-result-actions">
+              <button type="button" className="btn btn-primary" onClick={handleSaveToProfile} disabled={saving}>
+                {saving ? 'Saving...' : 'Save to My Profile'}
+              </button>
+              <button type="button" className="btn btn-secondary" onClick={() => navigate('/scan')}>
+                Start Skin Scan
+              </button>
+              <button type="button" className="quiz-retake" onClick={() => { setStep(0); setAnswers({}); setResult(null); }}>
+                Retake Quiz
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default SkinTypeQuizPage;

--- a/frontend/src/pages/TodayPage.tsx
+++ b/frontend/src/pages/TodayPage.tsx
@@ -253,6 +253,22 @@ const TodayPage: React.FC = () => {
     } else {
       setCompletedEvening(next);
     }
+
+    // Sync to backend (non-blocking)
+    const token = localStorage.getItem(STORAGE_KEYS.AUTH_TOKEN);
+    if (token) {
+      const steps = routineType === 'morning' ? morningSteps : eveningSteps;
+      const completed = routineType === 'morning' ? next : next;
+      fetch(`${API_BASE_URL}/routines/checkin`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          routine_type: routineType,
+          steps_completed: completed.size,
+          steps_total: steps.length,
+        }),
+      }).catch(() => {}); // Silent — localStorage is the source of truth
+    }
   };
 
   const firstName = user?.full_name?.split(' ')[0] || user?.email?.split('@')[0] || 'there';


### PR DESCRIPTION
- TodayPage: Sync routine check-ins to POST /routines/checkin on every step toggle (non-blocking, localStorage stays source of truth)
- AnalysisResults: Fetch top 3 product recommendations based on detected concerns, display as linked cards before action buttons
- NEW SkinTypeQuizPage: 6-question interactive quiz that determines skin type (dry/oily/combo/sensitive) and saves to profile via PATCH /profile. Route: /skin-quiz
- Backend: Seed 5 real blog articles on startup (morning routine, ingredient interactions, scan tips, skin types, retinol science) with full HTML content, categories, and tags

https://claude.ai/code/session_016XpCGMkdoVXBdD3E6dHejV

### Summary

- **What**: One-line summary of the change
- **Why**: Short justification and links to SRS/backlog

### Changes

- Files and modules changed (example: `backend/app/services/auth_service.py`)

### How to run / test locally

```bash
cd backend
pytest -q
```

### Checklist

- [ ] Tests added or updated
- [ ] Documentation updated (`docs/PROJECT_PROGRESS_TRACKER.md` or relevant doc)
- [ ] Env changes documented (`backend/.env.example`)
- [ ] DB migrations added (if schema changes)

### Notes for reviewers

- Any important notes about the change, deployment steps, or potential impacts
