### PR TITLE
fix: backend startup crash — date|None type syntax error

### DIFF
--- a/backend/app/api/v1/routines.py
+++ b/backend/app/api/v1/routines.py
@@ -1,4 +1,5 @@
-from datetime import date, datetime, timedelta
+from datetime import date as date_type, datetime, timedelta
+from typing import Optional
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -23,7 +24,7 @@ class CheckinRequest(BaseModel):
     routine_type: str = Field(..., description="'morning' or 'evening'")
     steps_completed: int = Field(..., ge=0)
     steps_total: int = Field(..., ge=1)
-    date: date | None = None  # defaults to today
+    date: Optional[date_type] = None  # defaults to today
 
 
 class CheckinResponse(BaseModel):
@@ -166,7 +167,7 @@ def record_checkin(
     current_user: User = Depends(get_current_user),
 ):
     """Record a routine completion for today (or a specific date)."""
-    checkin_date = payload.date or date.today()
+    checkin_date = payload.date or date_type.today()
 
     # Upsert: update if already checked in for this type+date
     existing = (
@@ -219,7 +220,7 @@ def get_adherence(
     current_user: User = Depends(get_current_user),
 ):
     """Get routine adherence stats for the last N days."""
-    since = date.today() - timedelta(days=days)
+    since = date_type.today() - timedelta(days=days)
 
     checkins = (
         db.query(RoutineCheckin)
@@ -241,7 +242,7 @@ def get_adherence(
     current_streak = 0
     longest_streak = 0
     streak = 0
-    today = date.today()
+    today = date_type.today()
 
     # Check from today backwards
     for i in range(days):
@@ -297,7 +298,7 @@ def get_routine_streak(
 
     checked_dates = sorted({c.checked_in_at.date() for c in checkins}, reverse=True)
     streak = 0
-    today = date.today()
+    today = date_type.today()
 
     for i, d in enumerate(checked_dates):
         expected = today - timedelta(days=i)

--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -1,5 +1,6 @@
 """Weekly progress summary report endpoint."""
 from datetime import date, datetime, timedelta
+from typing import Optional
 
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
@@ -19,8 +20,8 @@ router = APIRouter(prefix="/reports", tags=["reports"])
 class WeeklySummaryResponse(BaseModel):
     scans_this_week: int
     scans_last_week: int
-    avg_score_this_week: float | None
-    avg_score_last_week: float | None
+    avg_score_this_week: Optional[float]
+    avg_score_last_week: Optional[float]
     score_trend: str  # "improving" | "stable" | "declining"
     routine_adherence_pct: float
     routine_days_completed: int


### PR DESCRIPTION
The field `date: date | None` in CheckinRequest shadowed the `date` type import, causing TypeError on startup. Fixed by:
- Importing `date as date_type` to avoid shadowing
- Using `Optional[date_type]` and `Optional[float]` instead of `X | None` for broader Python 3.11 compatibility with Pydantic v2

This was causing Railway healthcheck failures (11 attempts, all failed).

https://claude.ai/code/session_016XpCGMkdoVXBdD3E6dHejV

### Summary

- **What**: One-line summary of the change
- **Why**: Short justification and links to SRS/backlog

### Changes

- Files and modules changed (example: `backend/app/services/auth_service.py`)

### How to run / test locally

```bash
cd backend
pytest -q
```

### Checklist

- [ ] Tests added or updated
- [ ] Documentation updated (`docs/PROJECT_PROGRESS_TRACKER.md` or relevant doc)
- [ ] Env changes documented (`backend/.env.example`)
- [ ] DB migrations added (if schema changes)

### Notes for reviewers

- Any important notes about the change, deployment steps, or potential impacts
