### PR TITLE
fix: UI audit — move inline styles to CSS, fix design token consistency

### DIFF
--- a/frontend/src/pages/AIChatPage.module.css
+++ b/frontend/src/pages/AIChatPage.module.css
@@ -32,7 +32,7 @@
     z-index: 1100;
     width: 300px;
     transform: translateX(-100%);
-    transition: transform var(--transition-slow, 300ms);
+    transition: transform 200ms ease-out;
     box-shadow: var(--shadow-xl, 0 20px 40px rgba(31, 111, 235, 0.15));
   }
   .sidebarOpen {

--- a/frontend/src/pages/AnalysisResults.css
+++ b/frontend/src/pages/AnalysisResults.css
@@ -948,3 +948,56 @@
     grid-template-columns: repeat(3, 1fr);
   }
 }
+
+/* ── Product Recommendations Section ── */
+.results-recs-section { margin-top: var(--spacing-lg, 24px); }
+.results-recs-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: var(--spacing-sm, 12px);
+}
+.results-rec-card {
+  display: flex;
+  flex-direction: column;
+  padding: var(--spacing-md, 16px);
+  background: var(--bg-secondary, #f6f8fb);
+  border-radius: var(--radius-lg, 12px);
+  border: 1px solid var(--border-color, #e4e9ef);
+  text-decoration: none;
+  color: inherit;
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+.results-rec-card:hover {
+  box-shadow: var(--shadow-md, 0 4px 12px rgba(0,0,0,0.06));
+  transform: translateY(-2px);
+}
+.results-rec-category {
+  font-size: var(--font-size-xs, 0.7rem);
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.results-rec-name {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 4px 0 2px;
+}
+.results-rec-brand {
+  font-size: var(--font-size-sm, 0.8rem);
+  color: var(--text-secondary);
+}
+.results-rec-rating {
+  font-size: 0.75rem;
+  color: var(--primary);
+  margin-top: 6px;
+}
+.results-recs-link {
+  display: inline-block;
+  margin-top: var(--spacing-sm, 12px);
+  font-size: var(--font-size-sm, 0.85rem);
+  color: var(--primary);
+  font-weight: 600;
+}
+.results-recs-link:hover { text-decoration: underline; }

--- a/frontend/src/pages/AnalysisResults.tsx
+++ b/frontend/src/pages/AnalysisResults.tsx
@@ -838,31 +838,22 @@ const AnalysisResults: React.FC = () => {
 
         {/* Product Recommendations for Detected Concerns */}
         {recProducts.length > 0 && (
-          <div className="results-section" style={{ marginTop: 24 }}>
+          <div className="results-section results-recs-section">
             <h2 className="results-section-title">
               <IconShoppingCart size={20} strokeWidth={2} className="icon-inline" />
               Recommended for Your Concerns
             </h2>
-            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))', gap: 12 }}>
+            <div className="results-recs-grid">
               {recProducts.map(p => (
-                <Link
-                  key={p.id}
-                  to={`/product/${encodeURIComponent(p.id)}`}
-                  style={{
-                    display: 'flex', flexDirection: 'column', padding: 16,
-                    background: 'var(--bg-secondary, #f6f8fb)', borderRadius: 12,
-                    border: '1px solid var(--border-color, #e4e9ef)',
-                    textDecoration: 'none', color: 'inherit', transition: 'box-shadow 0.2s',
-                  }}
-                >
-                  <span style={{ fontSize: '0.7rem', fontWeight: 600, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>{p.category}</span>
-                  <span style={{ fontSize: '0.9rem', fontWeight: 700, color: 'var(--text-primary)', margin: '4px 0 2px' }}>{p.name}</span>
-                  <span style={{ fontSize: '0.8rem', color: 'var(--text-secondary)' }}>{p.brand}</span>
-                  {p.rating && <span style={{ fontSize: '0.75rem', color: 'var(--primary)', marginTop: 6 }}>Rating: {p.rating}/5</span>}
+                <Link key={p.id} to={`/product/${encodeURIComponent(p.id)}`} className="results-rec-card">
+                  <span className="results-rec-category">{p.category}</span>
+                  <span className="results-rec-name">{p.name}</span>
+                  <span className="results-rec-brand">{p.brand}</span>
+                  {p.rating && <span className="results-rec-rating">Rating: {p.rating}/5</span>}
                 </Link>
               ))}
             </div>
-            <Link to="/recommendations" style={{ display: 'inline-block', marginTop: 12, fontSize: '0.85rem', color: 'var(--primary)', fontWeight: 600 }}>
+            <Link to="/recommendations" className="results-recs-link">
               View all recommendations &rarr;
             </Link>
           </div>

--- a/frontend/src/pages/AuthPage.css
+++ b/frontend/src/pages/AuthPage.css
@@ -8,7 +8,7 @@
   font-family: var(--font-family);
 }
 
-@media (max-width: 900px) {
+@media (max-width: 768px) {
   .auth-page {
     flex-direction: column;
   }
@@ -496,7 +496,7 @@
   margin: 0;
 }
 
-@media (max-width: 900px) {
+@media (max-width: 768px) {
   .auth-left {
     display: none;
   }

--- a/frontend/src/pages/DashboardPage.css
+++ b/frontend/src/pages/DashboardPage.css
@@ -1098,3 +1098,31 @@
     gap: var(--spacing-lg, 24px);
   }
 }
+
+/* ── Dashboard Widgets (replacing inline styles) ── */
+.dash-widget { padding: var(--spacing-lg, 20px); }
+.dash-widget-grid-3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--spacing-sm, 12px); margin-bottom: var(--spacing-sm, 12px); }
+.dash-widget-metric { text-align: center; }
+.dash-metric-value { font-size: var(--font-size-xl, 1.25rem); font-weight: 700; color: var(--primary); display: block; }
+.dash-metric-label { font-size: var(--font-size-xs, 0.7rem); color: var(--text-muted); display: block; }
+.dash-trend-improving { color: var(--success, #16a34a); }
+.dash-trend-declining { color: var(--danger, #dc2626); }
+.dash-trend-stable { color: var(--text-primary); }
+.dash-widget-insight { font-size: var(--font-size-sm, 0.825rem); color: var(--text-secondary); line-height: 1.5; margin: 0; }
+
+/* Adherence */
+.dash-adherence-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: var(--spacing-sm, 12px); }
+.dash-adherence-period { font-size: var(--font-size-sm, 0.85rem); color: var(--text-secondary); }
+.dash-adherence-bars { display: flex; gap: 4px; }
+.dash-adherence-day { flex: 1; text-align: center; }
+.dash-adherence-bar { width: 100%; height: 28px; border-radius: var(--radius-sm, 6px); background: var(--bg-tertiary, #eef2f6); }
+.dash-adherence-bar--done { background: var(--primary); }
+.dash-adherence-label { font-size: 0.65rem; color: var(--text-muted); margin-top: 4px; display: block; }
+.dash-streak-text { font-size: var(--font-size-sm, 0.8rem); color: var(--text-muted); margin-top: var(--spacing-xs, 8px); }
+
+/* Prediction */
+.dash-prediction-score { display: flex; align-items: baseline; gap: 8px; margin-bottom: 8px; }
+.dash-prediction-num { font-size: 1.5rem; font-weight: 800; color: var(--primary); }
+.dash-prediction-label { font-size: var(--font-size-sm, 0.8rem); color: var(--text-muted); }
+.dash-prediction-tags { margin-top: 10px; display: flex; gap: 6px; flex-wrap: wrap; }
+.dash-prediction-tag { font-size: var(--font-size-xs, 0.7rem); font-weight: 600; padding: 3px 10px; background: rgba(var(--primary-rgb), 0.06); color: var(--primary); border-radius: var(--radius-full, 12px); }

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -437,24 +437,24 @@ const DashboardPage: React.FC = () => {
         {weeklySummary && (
           <div className="app-section dashboard-section">
             <h2 className="app-section-title">This Week</h2>
-            <div className="app-card" style={{ padding: 20 }}>
-              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 12, marginBottom: 12 }}>
-                <div style={{ textAlign: 'center' }}>
-                  <span style={{ fontSize: '1.25rem', fontWeight: 700, color: 'var(--primary)' }}>{weeklySummary.scans_this_week}</span>
-                  <span style={{ display: 'block', fontSize: '0.7rem', color: 'var(--text-muted)' }}>Scans</span>
+            <div className="app-card dash-widget">
+              <div className="dash-widget-grid-3">
+                <div className="dash-widget-metric">
+                  <span className="dash-metric-value">{weeklySummary.scans_this_week}</span>
+                  <span className="dash-metric-label">Scans</span>
                 </div>
-                <div style={{ textAlign: 'center' }}>
-                  <span style={{ fontSize: '1.25rem', fontWeight: 700, color: weeklySummary.score_trend === 'improving' ? '#16a34a' : weeklySummary.score_trend === 'declining' ? '#dc2626' : 'var(--text-primary)' }}>
+                <div className="dash-widget-metric">
+                  <span className={`dash-metric-value dash-trend-${weeklySummary.score_trend}`}>
                     {weeklySummary.score_trend === 'improving' ? '↑' : weeklySummary.score_trend === 'declining' ? '↓' : '→'}
                   </span>
-                  <span style={{ display: 'block', fontSize: '0.7rem', color: 'var(--text-muted)' }}>Score Trend</span>
+                  <span className="dash-metric-label">Score Trend</span>
                 </div>
-                <div style={{ textAlign: 'center' }}>
-                  <span style={{ fontSize: '1.25rem', fontWeight: 700, color: 'var(--primary)' }}>{weeklySummary.routine_adherence_pct}%</span>
-                  <span style={{ display: 'block', fontSize: '0.7rem', color: 'var(--text-muted)' }}>Adherence</span>
+                <div className="dash-widget-metric">
+                  <span className="dash-metric-value">{weeklySummary.routine_adherence_pct}%</span>
+                  <span className="dash-metric-label">Adherence</span>
                 </div>
               </div>
-              <p style={{ fontSize: '0.825rem', color: 'var(--text-secondary)', lineHeight: 1.5, margin: 0 }}>{weeklySummary.insight}</p>
+              <p className="dash-widget-insight">{weeklySummary.insight}</p>
             </div>
           </div>
         )}
@@ -463,24 +463,21 @@ const DashboardPage: React.FC = () => {
         {routineAdherence && routineAdherence.completion_rate > 0 && (
           <div className="app-section dashboard-section">
             <h2 className="app-section-title">Routine Adherence</h2>
-            <div className="app-card" style={{ padding: 20 }}>
-              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
-                <span style={{ fontSize: '0.85rem', color: 'var(--text-secondary)' }}>Last 30 days</span>
-                <span style={{ fontSize: '1.25rem', fontWeight: 700, color: 'var(--primary)' }}>{routineAdherence.completion_rate}%</span>
+            <div className="app-card dash-widget">
+              <div className="dash-adherence-header">
+                <span className="dash-adherence-period">Last 30 days</span>
+                <span className="dash-metric-value">{routineAdherence.completion_rate}%</span>
               </div>
-              <div style={{ display: 'flex', gap: 4 }}>
+              <div className="dash-adherence-bars">
                 {routineAdherence.this_week.map((d, i) => (
-                  <div key={i} style={{ flex: 1, textAlign: 'center' }}>
-                    <div style={{
-                      width: '100%', height: 28, borderRadius: 6,
-                      background: d.completed ? 'var(--primary)' : 'var(--bg-tertiary, #eef2f6)',
-                    }} />
-                    <span style={{ fontSize: '0.65rem', color: 'var(--text-muted)', marginTop: 4, display: 'block' }}>{d.day}</span>
+                  <div key={i} className="dash-adherence-day">
+                    <div className={`dash-adherence-bar ${d.completed ? 'dash-adherence-bar--done' : ''}`} />
+                    <span className="dash-adherence-label">{d.day}</span>
                   </div>
                 ))}
               </div>
               {routineAdherence.current_streak > 0 && (
-                <p style={{ fontSize: '0.8rem', color: 'var(--text-muted)', marginTop: 8 }}>
+                <p className="dash-streak-text">
                   Current streak: {routineAdherence.current_streak} day{routineAdherence.current_streak !== 1 ? 's' : ''}
                 </p>
               )}
@@ -492,24 +489,20 @@ const DashboardPage: React.FC = () => {
         {prediction && (prediction.projected_score || prediction.summary) && (
           <div className="app-section dashboard-section">
             <h2 className="app-section-title">4-Week Outlook</h2>
-            <div className="app-card" style={{ padding: 20 }}>
+            <div className="app-card dash-widget">
               {prediction.projected_score && (
-                <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginBottom: 8 }}>
-                  <span style={{ fontSize: '1.5rem', fontWeight: 800, color: 'var(--primary)' }}>{prediction.projected_score}</span>
-                  <span style={{ fontSize: '0.8rem', color: 'var(--text-muted)' }}>projected score</span>
+                <div className="dash-prediction-score">
+                  <span className="dash-prediction-num">{prediction.projected_score}</span>
+                  <span className="dash-prediction-label">projected score</span>
                 </div>
               )}
               {prediction.summary && (
-                <p style={{ fontSize: '0.85rem', color: 'var(--text-secondary)', lineHeight: 1.6, margin: 0 }}>{prediction.summary}</p>
+                <p className="dash-widget-insight">{prediction.summary}</p>
               )}
               {prediction.improvements && prediction.improvements.length > 0 && (
-                <div style={{ marginTop: 10, display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                <div className="dash-prediction-tags">
                   {prediction.improvements.map((imp, i) => (
-                    <span key={i} style={{
-                      fontSize: '0.7rem', fontWeight: 600, padding: '3px 10px',
-                      background: 'rgba(var(--primary-rgb), 0.06)', color: 'var(--primary)',
-                      borderRadius: 12,
-                    }}>{imp}</span>
+                    <span key={i} className="dash-prediction-tag">{imp}</span>
                   ))}
                 </div>
               )}

--- a/frontend/src/pages/HomePage.css
+++ b/frontend/src/pages/HomePage.css
@@ -609,7 +609,7 @@
   padding: 32px 24px;
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
-  border-radius: 22px;
+  border-radius: var(--radius-xl, 16px);
   transition: transform 0.25s ease, box-shadow 0.25s ease;
 }
 
@@ -796,7 +796,7 @@
 .faq-container {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--spacing-md, 16px);
   max-width: 720px;
   margin: 0 auto;
 }
@@ -821,7 +821,7 @@
   justify-content: space-between;
   width: 100%;
   padding: 20px 24px;
-  font-size: 0.95rem;
+  font-size: var(--font-size-sm, 0.875rem);
   font-weight: var(--font-weight-bold);
   color: var(--text-primary);
   background: none;
@@ -919,7 +919,7 @@
   font-weight: var(--font-weight-bold);
   padding: 16px 40px;
   border: none;
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-xl);
   cursor: pointer;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.15);
   transition: transform 0.2s ease, box-shadow 0.2s ease;


### PR DESCRIPTION
P0 fixes:
- AnalysisResults: Move product recommendation cards from inline style={{}} to proper CSS classes (.results-rec-card, etc.) with hover states and design tokens
- DashboardPage: Move 30+ inline styles to CSS classes for weekly summary, adherence heatmap, prediction widgets (.dash-widget, .dash-metric-value, .dash-adherence-bar, .dash-prediction-tag)

P1 fixes:
- HomePage: Step card border-radius 22px → var(--radius-xl)
- HomePage: FAQ gap 12px → var(--spacing-md, 16px)
- HomePage: FAQ summary font 0.95rem → var(--font-size-sm)
- HomePage: CTA button radius var(--radius-lg) → var(--radius-xl)
- AuthPage: Split layout breakpoint 900px → 768px (tablet fix)
- AIChatPage: Sidebar transition 300ms → 200ms (faster feel)

https://claude.ai/code/session_016XpCGMkdoVXBdD3E6dHejV

### Summary

- **What**: One-line summary of the change
- **Why**: Short justification and links to SRS/backlog

### Changes

- Files and modules changed (example: `backend/app/services/auth_service.py`)

### How to run / test locally

```bash
cd backend
pytest -q
```

### Checklist

- [ ] Tests added or updated
- [ ] Documentation updated (`docs/PROJECT_PROGRESS_TRACKER.md` or relevant doc)
- [ ] Env changes documented (`backend/.env.example`)
- [ ] DB migrations added (if schema changes)

### Notes for reviewers

- Any important notes about the change, deployment steps, or potential impacts
