### PR TITLE
perf: cache headers + focus states + product DB pool increase

### DIFF
--- a/backend/app/routers/catalog.py
+++ b/backend/app/routers/catalog.py
@@ -12,7 +12,7 @@ Updated: January 27, 2026 - Uses separate product database
 import logging
 from typing import List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
@@ -166,6 +166,7 @@ async def lookup_by_name_brand(
 
 @router.get("/search", response_model=CatalogSearchResponse)
 async def search_products(
+    response: Response,
     q: str = Query(..., description="Search query"),
     category: Optional[str] = Query(None, description="Filter by category"),
     brand: Optional[str] = Query(None, description="Filter by brand"),
@@ -188,6 +189,7 @@ async def search_products(
         offset=offset
     )
     
+    response.headers["Cache-Control"] = "public, max-age=120"
     return CatalogSearchResponse(
         products=[CatalogProductResponse(**p) for p in products],
         total=len(products),
@@ -491,6 +493,7 @@ async def list_import_jobs(
 
 @router.get("/brands", response_model=List[BrandResponse])
 async def list_brands(
+    response: Response,
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
     db: Session = Depends(get_product_db)
@@ -502,6 +505,7 @@ async def list_brands(
 
     from app.models.catalog_models import CatalogBrand
     
+    response.headers["Cache-Control"] = "public, max-age=300"
     brands = db.query(CatalogBrand).order_by(
         CatalogBrand.product_count.desc().nullslast()
     ).offset(offset).limit(limit).all()
@@ -522,6 +526,7 @@ async def list_brands(
 
 @router.get("/ingredients", response_model=List[IngredientResponse])
 async def list_ingredients(
+    response: Response,
     search: Optional[str] = Query(None, description="Search by name"),
     harmful_only: bool = Query(False, description="Only show harmful ingredients"),
     limit: int = Query(50, ge=1, le=200),
@@ -533,8 +538,9 @@ async def list_ingredients(
     """
     from sqlalchemy import func
 
+    response.headers["Cache-Control"] = "public, max-age=300"
     from app.models.catalog_models import CatalogIngredient
-    
+
     query = db.query(CatalogIngredient)
     
     if search:

--- a/backend/app/routers/goals.py
+++ b/backend/app/routers/goals.py
@@ -8,7 +8,7 @@ import logging
 from datetime import datetime
 from typing import List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Response, status
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
@@ -91,10 +91,11 @@ class GoalTypeInfo(BaseModel):
 # ===== Endpoints =====
 
 @router.get("/types", response_model=List[GoalTypeInfo])
-async def get_goal_types():
+async def get_goal_types(response: Response):
     """
     Get available goal types.
     """
+    response.headers["Cache-Control"] = "public, max-age=600"
     return [GoalTypeInfo(**gt) for gt in GOAL_TYPES]
 
 

--- a/frontend/src/pages/DashboardPage.css
+++ b/frontend/src/pages/DashboardPage.css
@@ -298,6 +298,11 @@
   border-color: var(--primary);
 }
 
+.activity-item-clickable:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
 /* Dashboard Stats Grid */
 .dashboard-stats {
   margin: 24px 0 32px;


### PR DESCRIPTION
Backend performance:
- Product DB pool: 2→5 connections, overflow 5→10
- Cache headers on catalog search (120s), brands (300s), ingredients (300s), goal types (600s)

Frontend accessibility:
- Add focus-visible to dashboard activity items
- All interactive dashboard elements now have visible focus rings

https://claude.ai/code/session_016XpCGMkdoVXBdD3E6dHejV

### Summary

- **What**: One-line summary of the change
- **Why**: Short justification and links to SRS/backlog

### Changes

- Files and modules changed (example: `backend/app/services/auth_service.py`)

### How to run / test locally

```bash
cd backend
pytest -q
```

### Checklist

- [ ] Tests added or updated
- [ ] Documentation updated (`docs/PROJECT_PROGRESS_TRACKER.md` or relevant doc)
- [ ] Env changes documented (`backend/.env.example`)
- [ ] DB migrations added (if schema changes)

### Notes for reviewers

- Any important notes about the change, deployment steps, or potential impacts
