### PR TITLE
fix: homepage content shifted right — center section headers

### DIFF
--- a/frontend/src/pages/HomePage.css
+++ b/frontend/src/pages/HomePage.css
@@ -57,7 +57,9 @@
 /* Shared section headers */
 .section-header {
   text-align: center;
-  margin-bottom: var(--section-header-gap);
+  max-width: 1200px;
+  margin: 0 auto var(--section-header-gap);
+  padding: 0 var(--section-padding-x);
 }
 
 .section-header h2 {


### PR DESCRIPTION
The .section-header had text-align: center but no max-width constraint, causing it to stretch full viewport width. Content grids below had max-width + margin: 0 auto, creating misalignment (headers flush-left, content centered-right).

Fix: Add max-width: 1200px and margin: 0 auto to .section-header, matching the largest content grid width. All sections now align.

https://claude.ai/code/session_016XpCGMkdoVXBdD3E6dHejV

### Summary

- **What**: One-line summary of the change
- **Why**: Short justification and links to SRS/backlog

### Changes

- Files and modules changed (example: `backend/app/services/auth_service.py`)

### How to run / test locally

```bash
cd backend
pytest -q
```

### Checklist

- [ ] Tests added or updated
- [ ] Documentation updated (`docs/PROJECT_PROGRESS_TRACKER.md` or relevant doc)
- [ ] Env changes documented (`backend/.env.example`)
- [ ] DB migrations added (if schema changes)

### Notes for reviewers

- Any important notes about the change, deployment steps, or potential impacts
