### PR TITLE
fix: homepage sections misaligned — global flex override on .section-…

### DIFF
--- a/frontend/src/pages/HomePage.css
+++ b/frontend/src/pages/HomePage.css
@@ -56,6 +56,7 @@
 
 /* Shared section headers */
 .section-header {
+  display: block;
   text-align: center;
   max-width: 1200px;
   margin: 0 auto var(--section-header-gap);


### PR DESCRIPTION
…header

Root cause: index.css line 399 sets .section-header to display: flex with justify-content: space-between, which overrides text-align: center from HomePage.css. This pushed section tags to the left and h2 titles off-center.

Fix: Add display: block to .section-header in HomePage.css to override the global flex rule. Combined with max-width: 1200px and margin: 0 auto, all section headers and content now center correctly.

https://claude.ai/code/session_016XpCGMkdoVXBdD3E6dHejV

### Summary

- **What**: One-line summary of the change
- **Why**: Short justification and links to SRS/backlog

### Changes

- Files and modules changed (example: `backend/app/services/auth_service.py`)

### How to run / test locally

```bash
cd backend
pytest -q
```

### Checklist

- [ ] Tests added or updated
- [ ] Documentation updated (`docs/PROJECT_PROGRESS_TRACKER.md` or relevant doc)
- [ ] Env changes documented (`backend/.env.example`)
- [ ] DB migrations added (if schema changes)

### Notes for reviewers

- Any important notes about the change, deployment steps, or potential impacts
