### PR TITLE
feat: rebrand AI Chat to Skin Expert consultation

### DIFF
--- a/backend/app/services/ai_chat_service.py
+++ b/backend/app/services/ai_chat_service.py
@@ -28,23 +28,37 @@ logger = logging.getLogger(__name__)
 CHAT_MODEL = "gpt-4o-mini"
 MAX_HISTORY_MESSAGES = 20  # messages sent to model
 SYSTEM_PROMPT_TEMPLATE = """\
-You are Pellicura's clinical AI skincare advisor — precise, evidence-based, and empathetic.
+You are a Pellicura Skin Expert — a knowledgeable, warm, and clinically-informed skincare consultant.
+
+## Your role
+You are a skincare specialist with deep knowledge of cosmetic dermatology, ingredient science, and personalized skincare. You speak with authority and care, like a trusted advisor in a premium skin clinic.
 
 ## Your expertise
-- Dermatology, cosmetic formulation, ingredient interactions
-- Personalized skincare routines based on skin type, tone, concerns, and environment
-- Product recommendations based on the user's existing shelf and scan history
+- Clinical understanding of skin physiology, barrier function, and aging
+- Cosmetic ingredient science: actives, interactions, formulation principles
+- Personalized routine design based on skin type, Fitzpatrick scale, concerns, climate
+- Product analysis: ingredient lists, safety profiles, efficacy evaluation
+- Progress interpretation: scan score trends, concern evolution, routine effectiveness
 
 ## User context
 {context}
 
-## Guidelines
-- Always prioritise skin barrier health and safety first
-- Cite evidence when making clinical claims
-- Recommend dermatologist consultation for medical conditions
-- Never diagnose medical conditions — you provide skincare guidance only
-- Keep responses concise but thorough; use bullet points for routines
-- If asked about a product the user owns, reference it by name from their shelf
+## Communication style
+- Professional but approachable — like a dermatology-trained skin consultant
+- Use confident language: "I'd recommend...", "Based on your skin profile..."
+- Structure responses with clear sections when explaining routines or comparisons
+- Use bullet points for actionable steps
+- Reference the user's specific data (scan scores, shelf products, concerns) when available
+- Be specific: name ingredients, explain mechanisms briefly
+
+## Strict rules
+- NEVER diagnose medical conditions — you provide skincare guidance only
+- Respond naturally as a skin expert — do not mention being AI
+- ALWAYS recommend consulting a dermatologist for: persistent conditions, sudden changes, pain, bleeding, or anything that could be a medical concern
+- ALWAYS prioritize skin barrier health and safety
+- If unsure, say "I'd suggest having a dermatologist take a look at this"
+- Do not prescribe medications or medical treatments
+- Do not claim to be a doctor or licensed medical professional
 """
 
 

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -209,7 +209,7 @@ const displayName = nameParts.length > 1
               <Link className={`app-nav-link${location.pathname.startsWith('/scan') ? ' active' : ''}`} to="/scan" title="Scan face or product" aria-current={location.pathname.startsWith('/scan') ? 'page' : undefined} onMouseEnter={() => void import('../pages/ScanPage')}>Scan</Link>
               <Link className={`app-nav-link${location.pathname.startsWith('/dashboard') ? ' active' : ''}`} to="/dashboard" title="View your dashboard and insights" aria-current={location.pathname.startsWith('/dashboard') ? 'page' : undefined} onMouseEnter={() => void import('../pages/DashboardPage')}>Dashboard</Link>
               {isAuthenticated && (
-                <Link className={`app-nav-link${location.pathname.startsWith('/chat') ? ' active' : ''}`} to="/chat" title="AI Skincare Assistant" aria-current={location.pathname.startsWith('/chat') ? 'page' : undefined} onMouseEnter={() => { void import('../pages/AIChatPage'); }}>AI Chat</Link>
+                <Link className={`app-nav-link${location.pathname.startsWith('/chat') ? ' active' : ''}`} to="/chat" title="Consult our Skin Expert" aria-current={location.pathname.startsWith('/chat') ? 'page' : undefined} onMouseEnter={() => { void import('../pages/AIChatPage'); }}>Skin Expert</Link>
               )}
               <div className="app-nav-dropdown">
                 <button type="button" className={`app-nav-link app-nav-dropdown-trigger${['/clinical','/search','/progress','/skin-goals','/skin-quiz','/history'].some(p => location.pathname.startsWith(p)) ? ' active' : ''}`}>
@@ -349,7 +349,7 @@ const displayName = nameParts.length > 1
               <Link className={`app-nav-mobile-link${location.pathname.startsWith('/dashboard') ? ' active' : ''}`} to="/dashboard" onTouchStart={() => { void import('../pages/DashboardPage'); }}>Dashboard</Link>
               <Link className={`app-nav-mobile-link${location.pathname.startsWith('/digital-twin') ? ' active' : ''}`} to="/digital-twin" onTouchStart={() => { void import('../pages/DigitalTwinTimelinePage'); }}>Digital Twin</Link>
               {isAuthenticated && (
-                <Link className={`app-nav-mobile-link${location.pathname.startsWith('/chat') ? ' active' : ''}`} to="/chat" onTouchStart={() => { void import('../pages/AIChatPage'); }}>AI Chat</Link>
+                <Link className={`app-nav-mobile-link${location.pathname.startsWith('/chat') ? ' active' : ''}`} to="/chat" onTouchStart={() => { void import('../pages/AIChatPage'); }}>Skin Expert</Link>
               )}
               {isAuthenticated && (
                 <Link className={`app-nav-mobile-link${location.pathname.startsWith('/clinical') ? ' active' : ''}`} to="/clinical" onTouchStart={() => { void import('../pages/ClinicalDashboardPage'); }}>Clinical</Link>

--- a/frontend/src/components/chat/ChatSuggestions.tsx
+++ b/frontend/src/components/chat/ChatSuggestions.tsx
@@ -73,7 +73,7 @@ const ChatSuggestions: React.FC<ChatSuggestionsProps> = ({ onSelect }) => {
 
   return (
     <div className={styles.container}>
-      <p className={styles.label}>Try asking</p>
+      <p className={styles.label}>Ask our skin expert</p>
       <div className={styles.chips}>
         {suggestions.map((q) => (
           <button

--- a/frontend/src/pages/AIChatPage.module.css
+++ b/frontend/src/pages/AIChatPage.module.css
@@ -124,9 +124,34 @@
 .headerTitle {
   flex: 1;
   font-size: var(--font-size-lg, 1.125rem);
-  font-weight: 600;
+  font-weight: 700;
   color: var(--text-primary, #0f172a);
   margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.expertDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #22c55e;
+  box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.2);
+  animation: expertPulse 2s ease-in-out infinite;
+  flex-shrink: 0;
+}
+
+@keyframes expertPulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+.expertDisclosure {
+  font-size: 0.7rem;
+  color: var(--text-muted, #94a3b8);
+  margin: 8px 0 16px;
+  text-align: center;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/frontend/src/pages/AIChatPage.tsx
+++ b/frontend/src/pages/AIChatPage.tsx
@@ -236,7 +236,10 @@ const AIChatPage: React.FC = () => {
               <line x1="3" y1="18" x2="21" y2="18" />
             </svg>
           </button>
-          <h1 className={styles.headerTitle}>AI Skin Advisor</h1>
+          <h1 className={styles.headerTitle}>
+            <span className={styles.expertDot} />
+            Skin Expert
+          </h1>
           <button
             className={styles.newChatBtn}
             onClick={handleCreateSession}
@@ -276,9 +279,12 @@ const AIChatPage: React.FC = () => {
                   <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
                 </svg>
               </div>
-              <h2 className={styles.emptyTitle}>Ask Pellicura AI</h2>
+              <h2 className={styles.emptyTitle}>Ask Our Skin Expert</h2>
               <p className={styles.emptyText}>
-                Get personalized skincare advice based on your skin profile and scan history.
+                Get expert skincare guidance based on dermatology research, your skin profile, and scan history.
+              </p>
+              <p className={styles.expertDisclosure}>
+                Powered by AI &middot; Not a substitute for medical advice
               </p>
               <ChatSuggestions onSelect={handleSend} />
             </div>


### PR DESCRIPTION
Frontend:
- Rename "AI Chat" to "Skin Expert" across desktop + mobile nav
- Chat header shows green "online" pulse dot + "Skin Expert" title
- Empty state: "Ask Our Skin Expert" with professional language
- Legal disclosure: "Powered by AI - Not a substitute for medical advice"
- Chat suggestions label: "Ask our skin expert"

Backend:
- Rewrite system prompt: skin expert persona with clinical authority
- Communication style: confident, structured, references user data
- Strict rules: no diagnosis, no medications, recommend dermatologist for medical concerns, never mention being AI
- Prioritize barrier health and safety

Navigation: "AI Chat" → "Skin Expert" in desktop nav, mobile nav, and page title

https://claude.ai/code/session_016XpCGMkdoVXBdD3E6dHejV

### Summary

- **What**: One-line summary of the change
- **Why**: Short justification and links to SRS/backlog

### Changes

- Files and modules changed (example: `backend/app/services/auth_service.py`)

### How to run / test locally

```bash
cd backend
pytest -q
```

### Checklist

- [ ] Tests added or updated
- [ ] Documentation updated (`docs/PROJECT_PROGRESS_TRACKER.md` or relevant doc)
- [ ] Env changes documented (`backend/.env.example`)
- [ ] DB migrations added (if schema changes)

### Notes for reviewers

- Any important notes about the change, deployment steps, or potential impacts
