### PR TITLE
feat: add Skin Expert section to homepage

### DIFF
--- a/frontend/src/pages/HomePage.css
+++ b/frontend/src/pages/HomePage.css
@@ -704,6 +704,156 @@
 }
 
 /* ==========================================================================
+   9.5. SKIN EXPERT SECTION
+   ========================================================================== */
+
+.skin-expert-section {
+  background: var(--bg-primary);
+  padding: var(--section-padding-y) var(--section-padding-x);
+}
+
+.skin-expert-container {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 48px;
+  align-items: center;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.skin-expert-text h2 {
+  font-size: var(--font-size-3xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--text-primary);
+  margin: 0 0 12px;
+  line-height: 1.2;
+}
+
+.skin-expert-text > p {
+  font-size: var(--font-size-base);
+  color: var(--text-secondary);
+  line-height: 1.6;
+  margin: 0 0 20px;
+  max-width: 480px;
+}
+
+.skin-expert-features {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.skin-expert-features li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  font-weight: var(--font-weight-medium);
+}
+
+.skin-expert-features .inline-icon {
+  color: var(--primary);
+  flex-shrink: 0;
+}
+
+/* Chat preview mockup */
+.skin-expert-preview {
+  display: flex;
+  justify-content: center;
+}
+
+.skin-expert-chat-preview {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-xl);
+  padding: 24px;
+  width: 100%;
+  max-width: 380px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: var(--shadow-lg);
+}
+
+.chat-bubble {
+  padding: 14px 18px;
+  border-radius: 16px;
+  font-size: var(--font-size-sm);
+  line-height: 1.55;
+  max-width: 90%;
+}
+
+.chat-bubble--user {
+  background: var(--primary);
+  color: white;
+  align-self: flex-end;
+  border-bottom-right-radius: 4px;
+}
+
+.chat-bubble--expert {
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  align-self: flex-start;
+  border-bottom-left-radius: 4px;
+}
+
+.expert-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
+  color: var(--primary);
+  margin-bottom: 6px;
+}
+
+.expert-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #22c55e;
+}
+
+@media (max-width: 1024px) {
+  .skin-expert-container {
+    grid-template-columns: 1fr;
+    gap: 32px;
+    text-align: center;
+  }
+  .skin-expert-text > p {
+    max-width: 500px;
+    margin-inline: auto;
+    margin-bottom: 20px;
+  }
+  .skin-expert-features {
+    align-items: center;
+  }
+  .skin-expert-text .btn {
+    margin-inline: auto;
+  }
+  .skin-expert-chat-preview {
+    max-width: 340px;
+    margin: 0 auto;
+  }
+}
+
+@media (max-width: 480px) {
+  .skin-expert-chat-preview {
+    max-width: 280px;
+    padding: 18px;
+  }
+  .chat-bubble {
+    font-size: var(--font-size-xs);
+    padding: 10px 14px;
+  }
+}
+
+/* ==========================================================================
    10. TESTIMONIALS SECTION
    ========================================================================== */
 

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -411,6 +411,38 @@ const HomePage: React.FC = () => {
         </div>
       </FadeInSection>
 
+      {/* Skin Expert CTA */}
+      <FadeInSection className="skin-expert-section">
+        <div className="skin-expert-container">
+          <div className="skin-expert-text">
+            <span className="section-tag">Ask an Expert</span>
+            <h2>Talk to Our Skin Expert</h2>
+            <p>Get personalized skincare guidance from our AI-powered skin consultant — trained on dermatology research, ingredient science, and your unique skin profile.</p>
+            <ul className="skin-expert-features">
+              <li><IconCheck size={16} strokeWidth={2} className="inline-icon" /> Personalized routine recommendations</li>
+              <li><IconCheck size={16} strokeWidth={2} className="inline-icon" /> Ingredient analysis &amp; conflict detection</li>
+              <li><IconCheck size={16} strokeWidth={2} className="inline-icon" /> Progress interpretation from your scans</li>
+              <li><IconCheck size={16} strokeWidth={2} className="inline-icon" /> Available 24/7, instant responses</li>
+            </ul>
+            <button type="button" className="btn btn-primary btn-primary--hero" onClick={() => navigate('/chat')}>
+              <IconSparkles size={18} strokeWidth={2} />
+              Ask Skin Expert
+            </button>
+          </div>
+          <div className="skin-expert-preview">
+            <div className="skin-expert-chat-preview">
+              <div className="chat-bubble chat-bubble--user">
+                My skin feels dry after using retinol. What should I do?
+              </div>
+              <div className="chat-bubble chat-bubble--expert">
+                <span className="expert-label"><span className="expert-dot" /> Skin Expert</span>
+                That's a common response when starting retinol. I'd recommend reducing frequency to every other night and adding a ceramide-rich moisturizer...
+              </div>
+            </div>
+          </div>
+        </div>
+      </FadeInSection>
+
       {/* Testimonials */}
       <FadeInSection className="testimonials-section">
         <div className="section-header">


### PR DESCRIPTION
Adds a new section between "How It Works" and Testimonials:
- Split layout: text + chat preview mockup
- Features list: personalized routines, ingredient analysis, progress interpretation, 24/7 availability
- CTA button: "Ask Skin Expert" → navigates to /chat
- Chat preview: shows sample user question + expert response with green "online" dot and "Skin Expert" label
- Fully responsive: stacks on tablet/mobile, shrinks preview on 480px

https://claude.ai/code/session_016XpCGMkdoVXBdD3E6dHejV

### Summary

- **What**: One-line summary of the change
- **Why**: Short justification and links to SRS/backlog

### Changes

- Files and modules changed (example: `backend/app/services/auth_service.py`)

### How to run / test locally

```bash
cd backend
pytest -q
```

### Checklist

- [ ] Tests added or updated
- [ ] Documentation updated (`docs/PROJECT_PROGRESS_TRACKER.md` or relevant doc)
- [ ] Env changes documented (`backend/.env.example`)
- [ ] DB migrations added (if schema changes)

### Notes for reviewers

- Any important notes about the change, deployment steps, or potential impacts
