### PR TITLE
fix: standardize spacing system across all pages

### DIFF
--- a/frontend/src/components/PageContainer.css
+++ b/frontend/src/components/PageContainer.css
@@ -20,7 +20,7 @@
 }
 
 .page-container--wide {
-  max-width: 1200px;
+  max-width: 1120px;
 }
 
 .page-container--full {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -87,9 +87,9 @@
   --accent-rgb: 79, 138, 217;
 
   /* Section spacing — tightened to eliminate excessive whitespace */
-  --section-padding-y: 36px;
+  --section-padding-y: 56px;
   --section-padding-x: var(--spacing-lg, 24px);
-  --section-header-gap: 24px;
+  --section-header-gap: 32px;
 
   /* Background Colors */
   --bg-primary: var(--white);
@@ -245,7 +245,7 @@
   --font-lg: clamp(16px, 4vw, 20px);
   --font-xl: clamp(20px, 5vw, 28px);
   /* Card spacing (audit standardization) */
-  --card-padding: 16px;
+  --card-padding: 24px;
   --card-radius: 16px;
   --card-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
   --card-margin-bottom: 16px;

--- a/frontend/src/pages/AboutPage.css
+++ b/frontend/src/pages/AboutPage.css
@@ -9,11 +9,11 @@
 .about-page .app-page-content.about-container {
   padding-top: 20px;
   padding-bottom: 80px;
-  max-width: 1200px;
+  max-width: 1120px;
 }
 
 .about-section {
-  max-width: 1200px;
+  max-width: 1120px;
   margin: 0 auto;
   padding: var(--spacing-2xl, 60px) var(--spacing-lg, 24px);
   margin-bottom: var(--spacing-2xl, 48px);

--- a/frontend/src/pages/AnalysisResults.css
+++ b/frontend/src/pages/AnalysisResults.css
@@ -29,7 +29,7 @@
 }
 
 .results-container {
-  max-width: 1200px;
+  max-width: 1120px;
   margin: 0 auto;
   display: flex;
   flex-direction: column;

--- a/frontend/src/pages/ComparisonPage.css
+++ b/frontend/src/pages/ComparisonPage.css
@@ -269,7 +269,7 @@
 
 @media (min-width: 1024px) {
   .comparison-page .app-page-content {
-    max-width: 1200px;
+    max-width: 1120px;
     margin: 0 auto;
     gap: 24px;
   }

--- a/frontend/src/pages/DashboardPage.css
+++ b/frontend/src/pages/DashboardPage.css
@@ -499,18 +499,18 @@
 
 /* Dashboard Content */
 .dashboard-content {
-  max-width: none;
-  margin: 0;
+  max-width: 1120px;
+  margin: 0 auto;
   padding: 0;
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 32px;
+  gap: 20px;
 }
 
 .dashboard-section {
   background: var(--bg-white);
   border-radius: var(--border-radius-md);
-  padding: var(--spacing-xl);
+  padding: var(--spacing-lg);
   box-shadow: var(--shadow-sm);
   border: 1px solid var(--border);
 }

--- a/frontend/src/pages/HomePage.css
+++ b/frontend/src/pages/HomePage.css
@@ -58,7 +58,7 @@
 .section-header {
   display: block;
   text-align: center;
-  max-width: 1200px;
+  max-width: 1120px;
   margin: 0 auto var(--section-header-gap);
   padding: 0 var(--section-padding-x);
 }
@@ -103,7 +103,7 @@
   grid-template-columns: 1.1fr 0.9fr;
   align-items: center;
   gap: 48px;
-  max-width: 1200px;
+  max-width: 1120px;
   margin: 0 auto;
   padding: 48px var(--section-padding-x) 40px;
   min-height: auto;
@@ -394,7 +394,7 @@
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 20px;
-  max-width: 1100px;
+  max-width: 1120px;
   margin: 0 auto;
 }
 
@@ -403,7 +403,7 @@
   flex-direction: column;
   align-items: center;
   gap: 12px;
-  padding: 24px 16px;
+  padding: 24px;
   background: rgba(255, 255, 255, 0.6);
   backdrop-filter: blur(16px);
   -webkit-backdrop-filter: blur(16px);
@@ -501,7 +501,7 @@
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: var(--spacing-xl);
-  max-width: 900px;
+  max-width: 1120px;
   margin: 0 auto;
   text-align: center;
 }
@@ -536,8 +536,8 @@
 .results-grid {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: 24px;
-  max-width: 1200px;
+  gap: 20px;
+  max-width: 1120px;
   margin: 0 auto;
 }
 
@@ -546,7 +546,7 @@
   flex-direction: column;
   align-items: center;
   text-align: center;
-  padding: 32px 24px;
+  padding: 24px;
   background: rgba(255, 255, 255, 0.8);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-xl);
@@ -598,8 +598,8 @@
 .steps-container {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 28px;
-  max-width: 1100px;
+  gap: 20px;
+  max-width: 1120px;
   margin: 0 auto;
 }
 
@@ -609,7 +609,7 @@
   flex-direction: column;
   align-items: center;
   text-align: center;
-  padding: 32px 24px;
+  padding: 24px;
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-xl, 16px);
@@ -717,7 +717,7 @@
   grid-template-columns: 1fr 1fr;
   gap: 48px;
   align-items: center;
-  max-width: 1100px;
+  max-width: 1120px;
   margin: 0 auto;
 }
 
@@ -860,8 +860,8 @@
 .testimonials-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 24px;
-  max-width: 1100px;
+  gap: 20px;
+  max-width: 1120px;
   margin: 0 auto;
 }
 
@@ -870,7 +870,7 @@
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-xl);
-  padding: 28px;
+  padding: 24px;
   overflow: hidden;
   transition: transform 0.25s ease, box-shadow 0.25s ease;
 }

--- a/frontend/src/pages/MyShelfPage.css
+++ b/frontend/src/pages/MyShelfPage.css
@@ -19,7 +19,7 @@
 }
 
 .myshelf-hero-inner {
-  max-width: 1200px;
+  max-width: 1120px;
   margin: 0 auto;
   display: flex;
   align-items: center;

--- a/frontend/src/pages/ProductComparePage.css
+++ b/frontend/src/pages/ProductComparePage.css
@@ -207,7 +207,7 @@
 
 @media (min-width: 1024px) {
   .product-compare-page .app-page-content {
-    max-width: 1200px;
+    max-width: 1120px;
     margin: 0 auto;
   }
 

--- a/frontend/src/pages/ProductScannerPage.css
+++ b/frontend/src/pages/ProductScannerPage.css
@@ -2005,7 +2005,7 @@
 
 @media (min-width: 1024px) {
   .scanner-container {
-    max-width: 1200px;
+    max-width: 1120px;
   }
 
   .mode-selector {

--- a/frontend/src/pages/Recommendations.css
+++ b/frontend/src/pages/Recommendations.css
@@ -537,7 +537,7 @@
   border: 1px solid var(--border-color);
   border-radius: var(--border-radius-xl);
   box-shadow: var(--shadow-md);
-  padding: 32px;
+  padding: 24px;
   text-align: center;
 }
 

--- a/frontend/src/pages/SampleReportPage.css
+++ b/frontend/src/pages/SampleReportPage.css
@@ -15,7 +15,7 @@
 }
 
 .sample-report-container {
-  max-width: 1200px;
+  max-width: 1120px;
   margin: 0 auto;
   padding: 16px 24px;
   width: 100%;

--- a/frontend/src/pages/ScanPage.css
+++ b/frontend/src/pages/ScanPage.css
@@ -934,7 +934,7 @@
 
 @media (min-width: 1024px) {
   .scan-container {
-    max-width: 1200px;
+    max-width: 1120px;
   }
 
   .scan-content {

--- a/frontend/src/pages/TodayPage.css
+++ b/frontend/src/pages/TodayPage.css
@@ -82,14 +82,14 @@
 
 @media (min-width: 1024px) {
   .today-header {
-    max-width: 1100px;
+    max-width: 1120px;
     margin: 0 auto;
     padding-left: 24px;
     padding-right: 24px;
   }
 
   .today-content {
-    max-width: 1100px;
+    max-width: 1120px;
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 20px;


### PR DESCRIPTION
Global tokens updated:
- --section-padding-y: 36px → 56px (more premium breathing room)
- --section-header-gap: 24px → 32px (headers disconnected from content)
- --card-padding: 16px → 24px (consistent card interior)

14 CSS files updated to unified layout system:
- All max-widths standardized to 1120px (was 900/1100/1200px mix)
- All card padding standardized to 24px (was 16/24/28/32px mix)
- Homepage grid gaps standardized to 20px (was 20/24/28/32px mix)
- Dashboard grid gap 32→20px, section padding 32→24px
- Dashboard content container now 1120px (was unlimited)
- Recommendations empty state padding 32→24px

Files: index.css, HomePage.css, DashboardPage.css, AnalysisResults.css, AboutPage.css, ComparisonPage.css, MyShelfPage.css, ProductComparePage.css, ProductScannerPage.css, SampleReportPage.css, ScanPage.css, TodayPage.css, Recommendations.css, PageContainer.css

https://claude.ai/code/session_016XpCGMkdoVXBdD3E6dHejV

### Summary

- **What**: One-line summary of the change
- **Why**: Short justification and links to SRS/backlog

### Changes

- Files and modules changed (example: `backend/app/services/auth_service.py`)

### How to run / test locally

```bash
cd backend
pytest -q
```

### Checklist

- [ ] Tests added or updated
- [ ] Documentation updated (`docs/PROJECT_PROGRESS_TRACKER.md` or relevant doc)
- [ ] Env changes documented (`backend/.env.example`)
- [ ] DB migrations added (if schema changes)

### Notes for reviewers

- Any important notes about the change, deployment steps, or potential impacts
