### PR TITLE
fix: homepage final spacing — stats grid + footer alignment

### DIFF
--- a/frontend/src/components/AppLayout.css
+++ b/frontend/src/components/AppLayout.css
@@ -1031,7 +1031,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 40px;
+  gap: 24px;
   flex-wrap: wrap;
 }
 
@@ -1100,11 +1100,11 @@
 }
 
 .app-footer-container {
-  max-width: var(--max-width-xl);
+  max-width: 1120px;
   margin: 0 auto;
   display: grid;
   grid-template-columns: 1.3fr 2fr;
-  gap: var(--spacing-3xl);
+  gap: 24px;
 }
 
 /* ---------- MOBILE ---------- */
@@ -1194,7 +1194,7 @@
 .app-footer-links {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: var(--spacing-xl);
+  gap: 24px;
   align-items: start;
 }
 

--- a/frontend/src/pages/HomePage.css
+++ b/frontend/src/pages/HomePage.css
@@ -500,7 +500,7 @@
 .stats-grid {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: var(--spacing-xl);
+  gap: 24px;
   max-width: 1120px;
   margin: 0 auto;
   text-align: center;


### PR DESCRIPTION
Stats grid:
- Gap: var(--spacing-xl) (32px) → 24px (matches card grid rhythm)

Footer:
- Container max-width: var(--max-width-xl) (1280px) → 1120px (aligns with main content width)
- Container gap: var(--spacing-3xl) (48px) → 24px (too much space between brand column and links)
- Links column gap: var(--spacing-xl) (32px) → 24px (tighter 4-column footer)
- Newsletter gap: 40px → 24px (text and input were too far apart)

No color changes. No elements added or removed.
FAQ (720px), CTA (640px), and Skin Expert (48px) preserved — these are intentionally different widths for their content type.

https://claude.ai/code/session_016XpCGMkdoVXBdD3E6dHejV

### Summary

- **What**: One-line summary of the change
- **Why**: Short justification and links to SRS/backlog

### Changes

- Files and modules changed (example: `backend/app/services/auth_service.py`)

### How to run / test locally

```bash
cd backend
pytest -q
```

### Checklist

- [ ] Tests added or updated
- [ ] Documentation updated (`docs/PROJECT_PROGRESS_TRACKER.md` or relevant doc)
- [ ] Env changes documented (`backend/.env.example`)
- [ ] DB migrations added (if schema changes)

### Notes for reviewers

- Any important notes about the change, deployment steps, or potential impacts
