### PR TITLE
fix: global design system standardization — 38 CSS files

### DIFF
--- a/frontend/src/pages/AboutPage.css
+++ b/frontend/src/pages/AboutPage.css
@@ -94,7 +94,7 @@
   padding: 0;
   margin: 0;
   display: grid;
-  gap: 10px;
+  gap: 12px;
   color: var(--text-gray);
 }
 

--- a/frontend/src/pages/AdminBlogsPage.css
+++ b/frontend/src/pages/AdminBlogsPage.css
@@ -21,7 +21,7 @@
 .admin-blogs-page .admin-form-card {
   background: var(--bg-white);
   border: 1px solid var(--border);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   padding: var(--spacing-lg);
   margin-bottom: var(--spacing-xl);
   box-shadow: var(--shadow-sm);
@@ -43,7 +43,7 @@
   width: 100%;
   padding: 10px 12px;
   border: 1px solid var(--border);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-size: 1rem;
 }
 
@@ -77,7 +77,7 @@
   padding: 16px 20px;
   background: var(--bg-white);
   border: 1px solid var(--border);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   box-shadow: var(--shadow-sm);
 }
 
@@ -103,7 +103,7 @@
   background: transparent;
   color: var(--text-gray);
   cursor: pointer;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
 }
 
 .admin-blogs-page .btn-icon:hover {

--- a/frontend/src/pages/AdminCatalogPage.css
+++ b/frontend/src/pages/AdminCatalogPage.css
@@ -21,7 +21,7 @@
   color: var(--danger);
   padding: var(--spacing-sm);
   background: rgba(185, 28, 28, 0.08);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
 }
 
 .admin-catalog-section {
@@ -45,7 +45,7 @@
 .admin-catalog-card {
   background: var(--bg-white);
   border: 1px solid var(--border-color);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   padding: var(--spacing-md);
   box-shadow: var(--shadow-sm);
 }

--- a/frontend/src/pages/AdminContentPage.css
+++ b/frontend/src/pages/AdminContentPage.css
@@ -48,7 +48,7 @@
   padding: 10px 18px;
   border: none;
   background: transparent;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-size: 0.95rem;
   font-weight: 500;
   color: var(--text-gray);
@@ -156,7 +156,7 @@
   width: 100%;
   padding: 10px 12px;
   border: 1px solid var(--border-color, #e2e8f0);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-size: 1rem;
 }
 
@@ -231,7 +231,7 @@
 .admin-image-preview img {
   max-width: 100%;
   height: auto;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   border: 1px solid var(--border-color, #e2e8f0);
 }
 
@@ -291,7 +291,7 @@
   background: transparent;
   color: var(--text-gray);
   cursor: pointer;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
 }
 
 .admin-list-actions .btn-icon:hover {

--- a/frontend/src/pages/AdminNewsPage.css
+++ b/frontend/src/pages/AdminNewsPage.css
@@ -21,7 +21,7 @@
 .admin-news-page .admin-form-card {
   background: var(--bg-white);
   border: 1px solid var(--border);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   padding: var(--spacing-lg);
   margin-bottom: var(--spacing-xl);
   box-shadow: var(--shadow-sm);
@@ -43,7 +43,7 @@
   width: 100%;
   padding: 10px 12px;
   border: 1px solid var(--border);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-size: 1rem;
 }
 
@@ -72,7 +72,7 @@
   padding: 16px 20px;
   background: var(--bg-white);
   border: 1px solid var(--border);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   box-shadow: var(--shadow-sm);
 }
 
@@ -109,7 +109,7 @@
   background: transparent;
   color: var(--text-gray);
   cursor: pointer;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
 }
 
 .admin-news-page .btn-icon:hover {

--- a/frontend/src/pages/AdminProductsPage.css
+++ b/frontend/src/pages/AdminProductsPage.css
@@ -23,7 +23,7 @@
   flex: 1;
   min-width: 240px;
   padding: 10px 14px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   border: 1px solid var(--border-color);
 }
 
@@ -46,13 +46,13 @@
 
 .admin-product-grid input {
   padding: 10px 12px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   border: 1px solid var(--border-color);
 }
 
 .admin-product-actions {
   display: flex;
-  gap: 10px;
+  gap: 12px;
   flex-wrap: wrap;
 }
 

--- a/frontend/src/pages/AdminUsersPage.css
+++ b/frontend/src/pages/AdminUsersPage.css
@@ -23,7 +23,7 @@
   flex: 1;
   min-width: 240px;
   padding: 10px 14px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   border: 1px solid var(--border-color);
 }
 

--- a/frontend/src/pages/AdminVideosPage.css
+++ b/frontend/src/pages/AdminVideosPage.css
@@ -21,7 +21,7 @@
 .admin-videos-page .admin-form-card {
   background: var(--bg-white);
   border: 1px solid var(--border);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   padding: var(--spacing-lg);
   margin-bottom: var(--spacing-xl);
   box-shadow: var(--shadow-sm);
@@ -44,7 +44,7 @@
   width: 100%;
   padding: 10px 12px;
   border: 1px solid var(--border);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-size: 1rem;
 }
 
@@ -78,7 +78,7 @@
   padding: 16px 20px;
   background: var(--bg-white);
   border: 1px solid var(--border);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   box-shadow: var(--shadow-sm);
 }
 
@@ -104,7 +104,7 @@
   background: transparent;
   color: var(--text-gray);
   cursor: pointer;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
 }
 
 .admin-videos-page .btn-icon:hover {

--- a/frontend/src/pages/AnalysisResults.css
+++ b/frontend/src/pages/AnalysisResults.css
@@ -102,7 +102,7 @@
   gap: 16px;
   flex-wrap: wrap;
   background: var(--bg-white);
-  padding: 32px;
+  padding: 24px;
   border-radius: var(--border-radius-lg);
   box-shadow: var(--shadow);
   border: 1px solid var(--border);
@@ -160,7 +160,7 @@
   border: 1px solid var(--border, #e2e8f0);
   color: var(--text-gray, #64748b);
   padding: 10px 16px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-size: 0.9375rem;
   font-weight: 500;
   text-decoration: none;
@@ -203,7 +203,7 @@
   border: 1px solid var(--border, #e2e8f0);
   color: var(--text-gray, #64748b);
   padding: 10px 16px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-size: 0.9375rem;
   font-weight: 500;
   cursor: pointer;
@@ -221,7 +221,7 @@
   border: 2px solid var(--primary);
   color: var(--primary);
   padding: 10px 20px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-weight: 600;
   font-size: 0.95rem;
   cursor: pointer;
@@ -240,7 +240,7 @@
   gap: 16px;
   flex-wrap: wrap;
   background: var(--bg-white);
-  padding: 24px 32px;
+  padding: 24px;
   border-radius: var(--border-radius-lg);
   box-shadow: var(--shadow);
   border: 1px solid var(--border);
@@ -252,7 +252,7 @@
   flex: 1;
   min-width: 200px;
   background: var(--bg-light);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   height: 10px;
   overflow: hidden;
   border: 1px solid var(--border);
@@ -261,7 +261,7 @@
 .confidence-fill {
   height: 100%;
   background: linear-gradient(90deg, var(--success) 0%, var(--primary) 100%);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   transition: width 0.4s ease;
   box-shadow: 0 2px 8px rgba(31, 111, 235, 0.3);
 }
@@ -305,7 +305,7 @@
   background: var(--bg-white);
   border: 1px solid var(--border);
   border-radius: var(--border-radius-lg);
-  padding: 32px;
+  padding: 24px;
   box-shadow: var(--shadow);
   transition: all 0.3s ease;
 }
@@ -369,7 +369,7 @@
   color: var(--text-gray);
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 12px;
   font-size: 0.95rem;
   justify-content: center;
   min-height: 220px;
@@ -398,7 +398,7 @@
   background: var(--primary-light);
   color: var(--primary);
   padding: 8px 16px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-weight: 600;
   font-size: 1rem;
   display: inline-block;
@@ -461,7 +461,7 @@
 .severity-title-row {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
 }
 
 .severity-icon {
@@ -470,7 +470,7 @@
   justify-content: center;
   width: 36px;
   height: 36px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   background: linear-gradient(135deg, rgba(59, 130, 246, 0.1) 0%, rgba(139, 92, 246, 0.1) 100%);
   color: var(--primary);
   flex-shrink: 0;
@@ -493,7 +493,7 @@
 
 .severity-bar {
   background: var(--bg-light);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   height: 10px;
   overflow: hidden;
   margin-bottom: 8px;
@@ -502,7 +502,7 @@
 
 .severity-fill {
   height: 100%;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   transition: width 0.4s ease;
 }
 
@@ -545,7 +545,7 @@
 .recommendations-list li {
   padding: 12px 16px;
   background: var(--bg-light);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   border-left: 4px solid var(--primary);
   color: var(--text-dark);
   font-size: 1rem;
@@ -555,7 +555,7 @@
 .history-table-wrapper {
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
 }
 
 .history-table {
@@ -592,7 +592,7 @@
   border: 2px solid var(--primary);
   color: var(--primary);
   padding: 8px 16px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-weight: 600;
   font-size: 0.875rem;
   cursor: pointer;
@@ -614,7 +614,7 @@
 
 .results-actions .btn {
   padding: 12px 24px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-weight: 600;
   font-size: 1rem;
   cursor: pointer;

--- a/frontend/src/pages/AuthPage.css
+++ b/frontend/src/pages/AuthPage.css
@@ -258,7 +258,7 @@
   background: none;
   color: var(--gray-500);
   cursor: pointer;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -347,7 +347,7 @@
   margin-top: 8px;
   background: rgba(31, 111, 235, 0.06);
   border: 1px solid rgba(31, 111, 235, 0.2);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   padding: 10px 12px;
   font-size: 0.85rem;
   color: var(--text-secondary);
@@ -404,7 +404,7 @@
   color: var(--white);
   padding: 12px 24px; /* Brand guideline: 12px 24px */
   border: none;
-  border-radius: var(--border-radius-md); /* Brand guideline: 8px */
+  border-radius: var(--radius-xl, 16px); /* Brand guideline: 8px */
   font-size: 1rem; /* Brand guideline: 16px Body */
   font-weight: 600; /* Brand guideline */
   cursor: pointer;
@@ -465,7 +465,7 @@
   text-decoration: none;
   background: transparent;
   border: 2px solid var(--primary);
-  border-radius: var(--border-radius-md); /* Brand guideline: 8px */
+  border-radius: var(--radius-xl, 16px); /* Brand guideline: 8px */
   padding: 12px 32px;
   cursor: pointer;
   transition: all 0.2s ease;
@@ -509,7 +509,7 @@
   border: 1px solid var(--success-200, #bbf7d0);
   color: var(--success);
   padding: 12px 16px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-size: 0.9rem;
 }
 
@@ -600,7 +600,7 @@
   text-decoration: none;
   background: transparent;
   border: 2px solid var(--primary);
-  border-radius: var(--border-radius-md); /* Brand guideline: 8px */
+  border-radius: var(--radius-xl, 16px); /* Brand guideline: 8px */
   padding: 12px 32px;
   margin-top: 12px;
   cursor: pointer;
@@ -663,7 +663,7 @@
 .error-message__button {
   min-height: 44px;
   padding: var(--spacing-sm) var(--spacing-md);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-size: var(--font-size-sm);
   font-weight: 600;
   cursor: pointer;
@@ -718,7 +718,7 @@
   color: var(--white);
   background: var(--primary); /* Brand blue */
   border: none;
-  border-radius: var(--border-radius-md); /* Brand guideline: 8px */
+  border-radius: var(--radius-xl, 16px); /* Brand guideline: 8px */
   cursor: pointer;
   transition: all 0.2s ease;
   box-shadow: 0 4px 12px rgba(31, 111, 235, 0.2);

--- a/frontend/src/pages/CommonStyles.css
+++ b/frontend/src/pages/CommonStyles.css
@@ -55,7 +55,7 @@
   background-color: var(--danger-light);
   color: var(--danger);
   padding: var(--spacing-md);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   margin: var(--spacing-md) 0;
 }
 
@@ -63,7 +63,7 @@
   background-color: var(--success-light);
   color: var(--success);
   padding: var(--spacing-md);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   margin: var(--spacing-md) 0;
 }
 
@@ -73,7 +73,7 @@
   padding: var(--spacing-md) var(--spacing-lg);
   min-height: 48px;
   border: none;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-size: var(--font-size-base);
   font-weight: 600;
   cursor: pointer;
@@ -106,7 +106,7 @@
   padding: var(--spacing-md) var(--spacing-lg);
   min-height: 48px;
   border: 1px solid var(--border);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-size: var(--font-size-base);
   font-weight: 600;
   cursor: pointer;
@@ -127,7 +127,7 @@
   padding: var(--spacing-md) var(--spacing-lg);
   min-height: 48px;
   border: 2px solid var(--primary);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-size: var(--font-size-base);
   font-weight: 600;
   cursor: pointer;
@@ -148,7 +148,7 @@
   padding: var(--spacing-sm) var(--spacing-md);
   min-height: 44px;
   border: none;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-size: var(--font-size-base);
   cursor: pointer;
   display: inline-flex;
@@ -247,7 +247,7 @@
   min-height: 44px;
   padding: var(--spacing-sm) var(--spacing-md);
   border: 1px solid var(--border);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-size: var(--font-size-base);
 }
 

--- a/frontend/src/pages/ComparisonPage.css
+++ b/frontend/src/pages/ComparisonPage.css
@@ -63,7 +63,7 @@
   width: 100%;
   min-height: 44px;
   padding: var(--spacing-md) var(--spacing-md);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   border: 1px solid var(--border);
   background: var(--bg-light);
   color: var(--text-dark);
@@ -159,7 +159,7 @@
 .btn-icon-small {
   background: transparent;
   border: 1px solid var(--border);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   padding: 8px;
   cursor: pointer;
   color: var(--text-gray);

--- a/frontend/src/pages/ConsentPage.css
+++ b/frontend/src/pages/ConsentPage.css
@@ -80,7 +80,7 @@
   padding: var(--spacing-md) var(--spacing-lg);
   min-height: 48px;
   border: none;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-weight: var(--font-weight-semibold);
   font-size: var(--font-size-base);
   cursor: pointer;
@@ -116,7 +116,7 @@
   background: var(--primary-light);
   color: var(--primary);
   padding: 12px 16px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-size: 0.875rem;
   margin-top: 12px;
   text-align: center;
@@ -141,7 +141,7 @@
 
   .consent-actions {
     flex-direction: column;
-    gap: 10px;
+    gap: 12px;
   }
 
   .consent-actions button {

--- a/frontend/src/pages/ContactPage.css
+++ b/frontend/src/pages/ContactPage.css
@@ -119,7 +119,7 @@
   margin-top: 12px;
   min-height: 44px;
   padding: 10px 20px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-size: 1rem;
   font-weight: 600;
   cursor: pointer;
@@ -176,7 +176,7 @@
   width: 100%;
   padding: 12px 16px; /* Brand guideline: 12px 16px */
   border: 1px solid var(--border);
-  border-radius: var(--border-radius-md); /* Brand guideline: 8px */
+  border-radius: var(--radius-xl, 16px); /* Brand guideline: 8px */
   font-size: 1rem; /* Brand guideline: 16px Body */
   background: var(--bg-light);
   transition: all 0.2s ease;
@@ -213,7 +213,7 @@
   background: var(--primary); /* Brand blue */
   color: var(--white);
   border: none;
-  border-radius: var(--border-radius-md); /* Brand guideline: 8px */
+  border-radius: var(--radius-xl, 16px); /* Brand guideline: 8px */
   font-size: 1rem; /* Brand guideline: 16px Body */
   font-weight: 600; /* Brand guideline */
   cursor: pointer;
@@ -234,7 +234,7 @@
   background: var(--primary);
   color: var(--white);
   border: none;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-size: 1rem;
   font-weight: 600;
   cursor: pointer;

--- a/frontend/src/pages/DashboardPage.css
+++ b/frontend/src/pages/DashboardPage.css
@@ -284,7 +284,7 @@
   width: 100%;
   appearance: none;
   border: 1px solid var(--border);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   padding: var(--spacing-md) var(--spacing-lg);
   background: var(--bg-white);
   display: flex;
@@ -548,7 +548,7 @@
 
 .action-card {
   background: var(--bg-light);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   padding: var(--spacing-lg);
   border: 2px solid transparent;
   cursor: pointer;
@@ -580,7 +580,7 @@
   height: 48px;
   min-width: 48px;
   min-height: 48px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   background: var(--bg-white);
   display: flex;
   align-items: center;
@@ -622,7 +622,7 @@
   gap: var(--spacing-md);
   padding: var(--spacing-md) var(--spacing-lg);
   background: var(--bg-white);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   border: 1px solid var(--border);
   transition: all 0.2s ease;
 }
@@ -635,7 +635,7 @@
 .activity-icon {
   width: 40px;
   height: 40px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   background: var(--bg-white);
   display: flex;
   align-items: center;
@@ -743,7 +743,7 @@
 .reminder-frequency-select {
   padding: 8px 12px;
   border: 1px solid var(--border, #e2e8f0);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-size: 1rem;
   min-width: 140px;
 }
@@ -773,7 +773,7 @@
   padding: 6px 12px;
   background: rgba(31, 111, 235, 0.1);
   color: var(--primary);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-size: 0.875rem;
   font-weight: 500;
 }
@@ -809,7 +809,7 @@
   text-align: left;
   background: var(--bg-white);
   border: 1px solid var(--border, #e2e8f0);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-size: 1rem;
   color: var(--text-dark);
   cursor: pointer;
@@ -866,7 +866,7 @@
   padding: 12px 16px;
   background: var(--bg-white);
   border: 1px solid var(--border, #e2e8f0);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   cursor: pointer;
   transition: background 0.2s, border-color 0.2s;
   max-width: 220px;
@@ -894,7 +894,7 @@
   background: var(--primary); /* Brand blue */
   color: var(--white);
   border: none;
-  border-radius: var(--border-radius-md); /* Brand guideline: 8px */
+  border-radius: var(--radius-xl, 16px); /* Brand guideline: 8px */
   font-size: 1rem; /* Brand guideline: 16px Body */
   font-weight: 600; /* Brand guideline */
   cursor: pointer;

--- a/frontend/src/pages/DataExportPage.css
+++ b/frontend/src/pages/DataExportPage.css
@@ -18,7 +18,7 @@
   min-width: 44px;
   min-height: 44px;
   color: var(--text-primary);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   flex-shrink: 0;
 }
 .data-export-back:hover {
@@ -89,7 +89,7 @@
   padding: 16px;
   margin-bottom: 8px;
   background: var(--bg-light);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   border: 1px solid var(--border);
 }
 

--- a/frontend/src/pages/DeviceContextPage.css
+++ b/frontend/src/pages/DeviceContextPage.css
@@ -21,7 +21,7 @@
   justify-content: center;
   color: var(--text-primary);
   padding: 4px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
 }
 
 .device-ctx-back:hover {
@@ -76,7 +76,7 @@
   padding: 12px;
   background: rgba(239, 68, 68, 0.1);
   border: 1px solid rgba(239, 68, 68, 0.3);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   color: var(--text-primary);
   font-size: 0.9rem;
 }

--- a/frontend/src/pages/DigitalTwinTimelinePage.css
+++ b/frontend/src/pages/DigitalTwinTimelinePage.css
@@ -222,7 +222,7 @@
 
 .chart-controls select {
   border: 1px solid var(--border);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   padding: 8px 10px;
   font-size: 0.875rem;
   background: var(--bg-white);
@@ -352,7 +352,7 @@
   flex-direction: column;
   padding: 16px;
   background: var(--bg-light);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   min-width: 0;
 }
 
@@ -432,7 +432,7 @@
 
 .comparison-controls select {
   border: 1px solid var(--border);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   padding: 8px 10px;
   font-size: 0.875rem;
   background: var(--bg-white);

--- a/frontend/src/pages/EmailVerificationPage.css
+++ b/frontend/src/pages/EmailVerificationPage.css
@@ -37,7 +37,7 @@
 }
 
 .email-verification-card input {
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   border: 1px solid var(--border-color);
   padding: var(--spacing-md);
   min-height: 44px;
@@ -46,7 +46,7 @@
 
 .status-message {
   padding: var(--spacing-md);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-size: var(--font-size-base);
 }
 

--- a/frontend/src/pages/FavoritesPage.css
+++ b/frontend/src/pages/FavoritesPage.css
@@ -130,7 +130,7 @@
   flex: 1;
   padding: 10px 12px;
   border: 1px solid var(--border, #e2e8f0);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-size: 0.9375rem;
   background: var(--bg-light, #f8fafc);
 }
@@ -174,7 +174,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   color: var(--text-muted);
   background: transparent;
   border: none;

--- a/frontend/src/pages/GoogleCallbackPage.css
+++ b/frontend/src/pages/GoogleCallbackPage.css
@@ -68,7 +68,7 @@
   background: linear-gradient(135deg, var(--primary) 0%, var(--accent) 100%);
   color: var(--white);
   border: none;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-size: var(--font-size-base);
   font-weight: var(--font-weight-medium);
   cursor: pointer;
@@ -175,7 +175,7 @@
   background: var(--bg-white);
   color: var(--primary);
   border: 1px solid var(--border-color);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-medium);
   cursor: pointer;

--- a/frontend/src/pages/HistoryPage.css
+++ b/frontend/src/pages/HistoryPage.css
@@ -98,7 +98,7 @@
   min-height: 44px;
   background: var(--bg-white);
   border: 2px solid var(--border);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   color: var(--text-secondary);
   font-weight: var(--font-weight-medium);
   font-size: var(--font-size-base);
@@ -137,7 +137,7 @@
 .history-search {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
   flex: 1;
   min-width: 200px;
 }
@@ -151,7 +151,7 @@
   flex: 1;
   padding: 10px 14px;
   border: 1px solid var(--border);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-size: 1rem;
   background: var(--bg-light);
 }
@@ -203,7 +203,7 @@
 .history-sort-select {
   padding: 8px 12px;
   border: 1px solid var(--border);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-size: 0.9375rem;
   background: var(--bg-white);
   cursor: pointer;
@@ -280,7 +280,7 @@
 
 .history-item {
   background: var(--bg-white);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   padding: var(--spacing-lg);
   display: flex;
   align-items: center;
@@ -339,7 +339,7 @@
   height: 80px;
   min-width: 80px;
   min-height: 80px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   object-fit: cover;
   border: 2px solid var(--border);
   box-shadow: var(--shadow-sm);
@@ -395,7 +395,7 @@
   color: var(--danger-800, #9b1c1c);
   background: var(--danger-50, #fef2f2);
   border: 1px solid var(--danger-200, #fecaca);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   padding: 8px 12px;
 }
 
@@ -420,7 +420,7 @@
   padding: 10px 20px;
   background: var(--primary); /* Brand blue */
   border: none;
-  border-radius: var(--border-radius-md); /* Brand guideline: 8px */
+  border-radius: var(--radius-xl, 16px); /* Brand guideline: 8px */
   color: var(--white);
   font-weight: 600;
   font-size: 0.95rem;

--- a/frontend/src/pages/IngredientDictionaryPage.css
+++ b/frontend/src/pages/IngredientDictionaryPage.css
@@ -45,7 +45,7 @@
   min-width: 240px;
   min-height: 44px;
   padding: var(--spacing-md);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   border: 1px solid var(--border);
 }
 

--- a/frontend/src/pages/MyShelfPage.css
+++ b/frontend/src/pages/MyShelfPage.css
@@ -156,7 +156,7 @@
   width: 56px;
   height: 56px;
   object-fit: contain;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   background: var(--bg-secondary);
 }
 
@@ -175,7 +175,7 @@
   font-size: 0.7rem;
   font-weight: 600;
   padding: 4px 8px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
 }
 
 .myshelf-expiring-badge.warning {
@@ -429,7 +429,7 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
   margin-bottom: 20px;
 }
 
@@ -650,7 +650,7 @@
   text-transform: uppercase;
   letter-spacing: 0.03em;
   padding: 4px 10px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   align-self: flex-start;
   background: var(--gray-100);
   color: var(--text-muted);
@@ -734,11 +734,11 @@
   text-align: left;
   font-size: 0.9375rem;
   color: var(--text-primary);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
   transition: background 0.15s;
 }
 
@@ -755,7 +755,7 @@
 
 .product-card-actions-desk {
   display: flex;
-  gap: 10px;
+  gap: 12px;
   margin-top: auto;
   padding-top: 12px;
 }
@@ -856,7 +856,7 @@
   display: inline-block;
   font-size: 0.75rem;
   padding: 4px 10px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   background: var(--gray-100);
   color: var(--text-muted);
 }

--- a/frontend/src/pages/NotificationCenterPage.css
+++ b/frontend/src/pages/NotificationCenterPage.css
@@ -21,7 +21,7 @@
   min-width: 44px;
   min-height: 44px;
   color: rgba(255, 255, 255, 0.95);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   flex-shrink: 0;
 }
 .notif-back:hover {
@@ -40,7 +40,7 @@
 
 .notif-header-actions {
   display: flex;
-  gap: 10px;
+  gap: 12px;
   align-items: center;
   justify-content: center;
   margin-top: 12px;
@@ -52,7 +52,7 @@
   padding: 8px 14px;
   background: rgba(255, 255, 255, 0.25);
   border: 1px solid rgba(255, 255, 255, 0.6);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   color: var(--white);
   font-size: 0.875rem;
   font-weight: 500;
@@ -69,7 +69,7 @@
   padding: 0;
   background: rgba(255, 255, 255, 0.25);
   border: 1px solid rgba(255, 255, 255, 0.6);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   color: var(--white);
   cursor: pointer;
   display: inline-flex;
@@ -131,7 +131,7 @@
   font-size: 1rem;
   padding: 8px 12px;
   border: 1px solid var(--border);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   background: var(--bg-white);
   color: var(--text-primary);
   min-width: 120px;
@@ -184,7 +184,7 @@
   padding: 8px 16px;
   background: var(--bg-white);
   border: 1px solid var(--border);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   color: var(--text-secondary);
   font-weight: 500;
   cursor: pointer;
@@ -210,7 +210,7 @@
 
 .notification-item {
   background: var(--bg-white);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   padding: var(--spacing-lg);
   box-shadow: var(--shadow-sm);
   border: 1px solid var(--border);

--- a/frontend/src/pages/NotificationCenterPage.module.css
+++ b/frontend/src/pages/NotificationCenterPage.module.css
@@ -59,7 +59,7 @@
 
 .headerActions {
   display: flex;
-  gap: 10px;
+  gap: 12px;
   align-items: center;
   justify-content: center;
   margin-top: 12px;

--- a/frontend/src/pages/PasswordResetPage.css
+++ b/frontend/src/pages/PasswordResetPage.css
@@ -105,7 +105,7 @@
 .password-reset-alert {
   margin-bottom: 24px;
   padding: 16px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   background: var(--bg-light);
   border: 1px solid var(--border);
 }

--- a/frontend/src/pages/ProductComparePage.css
+++ b/frontend/src/pages/ProductComparePage.css
@@ -179,7 +179,7 @@
 .btn-secondary {
   display: inline-block;
   padding: 10px 20px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-size: 1rem;
   font-weight: 600;
   cursor: pointer;

--- a/frontend/src/pages/ProductDetailsPage.css
+++ b/frontend/src/pages/ProductDetailsPage.css
@@ -92,7 +92,7 @@
   display: inline-flex;
   align-items: center;
   padding: var(--spacing-sm) var(--spacing-md);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   background: transparent;
   border: 1px solid var(--border);
   color: var(--primary);
@@ -148,7 +148,7 @@
 
 .product-image-section img {
   width: 100%;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
 }
 
 .product-image-zoom-trigger {
@@ -157,7 +157,7 @@
   border: none;
   padding: 0;
   background: none;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
 }
 
 .product-image-zoom-trigger img {
@@ -180,7 +180,7 @@
   max-width: 90vw;
   max-height: 90vh;
   object-fit: contain;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   cursor: default;
   pointer-events: none;
 }
@@ -357,7 +357,7 @@
 .product-details-page .btn-outline {
   min-height: 44px;
   padding: 12px 20px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-weight: 600;
   font-size: var(--font-size-base);
   border: 1px solid transparent;
@@ -417,7 +417,7 @@
   border: none;
   min-height: 44px;
   padding: 10px 16px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-weight: 600;
   font-size: var(--font-size-base);
   color: var(--text-secondary);
@@ -467,7 +467,7 @@
 .ingredient-card {
   background: var(--bg-tertiary);
   padding: var(--spacing-sm);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   border: 1px solid var(--border);
   text-align: center;
   font-weight: 600;
@@ -515,7 +515,7 @@
 .review-form {
   background: var(--bg-tertiary);
   border: 1px solid var(--border);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   padding: var(--spacing-lg);
   margin-bottom: var(--spacing-lg);
 }
@@ -544,7 +544,7 @@
   min-height: 44px;
   padding: var(--spacing-sm) var(--spacing-md);
   border: 1px solid var(--border);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-size: var(--font-size-base);
   font-family: inherit;
 }
@@ -612,7 +612,7 @@
   background: var(--danger-light);
   color: var(--danger);
   padding: 12px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   margin-bottom: 16px;
 }
 
@@ -623,7 +623,7 @@
   gap: 32px;
   padding: 24px;
   background: var(--bg-tertiary);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   margin-bottom: 24px;
 }
 
@@ -690,7 +690,7 @@
 .review-card {
   background: var(--white);
   border: 1px solid var(--border-color);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   padding: 20px;
 }
 
@@ -917,7 +917,7 @@
   min-width: 200px;
   padding: 10px 14px;
   border: 1px solid var(--border-color);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-size: 0.9rem;
   transition: border-color 0.2s, box-shadow 0.2s;
 }
@@ -975,7 +975,7 @@
   margin-top: 16px;
   padding: 12px;
   background: var(--bg-secondary);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   flex-wrap: wrap;
 }
 
@@ -1094,7 +1094,7 @@
 .flagged-ingredients-section {
   background: linear-gradient(135deg, rgba(239, 68, 68, 0.05), rgba(249, 115, 22, 0.05));
   border: 2px solid var(--danger);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   padding: var(--spacing-lg);
   margin-bottom: var(--spacing-lg);
 }
@@ -1118,7 +1118,7 @@
 
 .flagged-item {
   background: var(--bg-white);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   padding: var(--spacing-md);
   border-left: 4px solid var(--text-muted);
 }
@@ -1204,14 +1204,14 @@
   margin-top: 8px;
   padding: 8px;
   background: var(--bg-tertiary);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
 }
 
 .safety-recommendations {
   margin-top: var(--spacing-md);
   padding: var(--spacing-md);
   background: rgba(245, 158, 11, 0.1);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   border: 1px solid rgba(245, 158, 11, 0.3);
 }
 
@@ -1229,7 +1229,7 @@
 .safety-badges {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
+  gap: 12px;
   margin-top: 16px;
 }
 
@@ -1257,7 +1257,7 @@
   padding: var(--spacing-md);
   background: rgba(239, 68, 68, 0.08);
   border: 1px solid var(--danger);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
 }
 
 .warnings-section h3 {

--- a/frontend/src/pages/ProductScannerPage.css
+++ b/frontend/src/pages/ProductScannerPage.css
@@ -122,7 +122,7 @@
 @media (max-width: 380px) {
   .mode-selector {
     flex-direction: column;
-    gap: 10px;
+    gap: 12px;
     margin-bottom: 24px;
   }
 
@@ -218,7 +218,7 @@
   padding: 16px;
   margin-top: 16px;
   background: rgba(31, 111, 235, 0.1);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   color: var(--primary);
   font-weight: 500;
 }
@@ -380,7 +380,7 @@
   background: var(--success);
   color: var(--white);
   border: none;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-weight: 600;
   font-size: 1rem;
   display: flex;
@@ -409,7 +409,7 @@
   font-size: 0.95rem;
   text-decoration: none;
   border: 2px solid var(--primary);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   transition: all 0.2s ease;
 }
 
@@ -499,7 +499,7 @@
   background: var(--primary);
   color: var(--white);
   border: none;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-weight: 500;
   cursor: pointer;
   transition: all 0.2s ease;
@@ -555,7 +555,7 @@
   text-align: center;
   background: rgba(0, 0, 0, 0.7);
   padding: 8px 16px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
 }
 
 .camera-placeholder {
@@ -583,7 +583,7 @@
   background: var(--primary);
   color: var(--white);
   border: none;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-size: 1.125rem;
   font-weight: 600;
   cursor: pointer;
@@ -733,7 +733,7 @@
 .btn-icon-small {
   background: transparent;
   border: 1px solid var(--border);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   padding: 8px;
   cursor: pointer;
   color: var(--text-gray);
@@ -773,14 +773,14 @@
   display: block;
   object-fit: contain;
   background: var(--bg-white);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
 }
 
 .product-image-placeholder {
   width: 120px;
   height: 120px;
   background: var(--bg-white);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -881,7 +881,7 @@
 .product-actions-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 10px;
+  gap: 12px;
 }
 .product-action-btn { justify-content: center; }
 .product-action-routine { grid-column: span 1; }
@@ -941,13 +941,13 @@
   width: 100%;
   padding: 10px 12px;
   border: 1px solid var(--border-color);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-size: 1rem;
 }
 .track-product-actions {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 12px;
   margin-top: 20px;
 }
 .track-product-actions .btn-ghost { margin-top: 4px; }
@@ -1036,7 +1036,7 @@
   margin-bottom: var(--spacing-lg);
   background: linear-gradient(135deg, rgba(59, 130, 246, 0.05), rgba(139, 92, 246, 0.05));
   border: 1px solid rgba(59, 130, 246, 0.2);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   padding: var(--spacing-lg);
 }
 
@@ -1064,7 +1064,7 @@
   gap: var(--spacing-sm);
   background: var(--bg-white);
   padding: var(--spacing-sm) var(--spacing-md);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   border: 1px solid var(--border);
 }
 
@@ -1114,7 +1114,7 @@
 .flagged-ingredients-section {
   background: linear-gradient(135deg, rgba(239, 68, 68, 0.05), rgba(249, 115, 22, 0.05));
   border: 2px solid var(--danger);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   padding: var(--spacing-lg);
   margin-bottom: var(--spacing-xl);
 }
@@ -1137,7 +1137,7 @@
 
 .flagged-item {
   background: var(--bg-white);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   padding: var(--spacing-md);
   border-left: 4px solid var(--text-muted);
 }
@@ -1228,7 +1228,7 @@
   margin-top: var(--spacing-sm);
   padding: var(--spacing-sm);
   background: var(--bg-tertiary);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
 }
 
 .flagged-alternatives strong,
@@ -1265,7 +1265,7 @@
   margin-top: var(--spacing-lg);
   padding: var(--spacing-md);
   background: var(--warning-light);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   border: 1px solid var(--warning);
 }
 
@@ -1291,7 +1291,7 @@
 .safety-badges {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
+  gap: 12px;
   margin-top: 16px;
 }
 
@@ -1363,7 +1363,7 @@
 .product-actions .btn-secondary {
   min-height: 48px;
   padding: var(--spacing-sm) var(--spacing-lg);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-weight: 600;
   font-size: var(--font-size-base);
   cursor: pointer;
@@ -1463,7 +1463,7 @@
   .camera-container {
     max-width: 100%;
     min-height: 200px;
-    border-radius: var(--border-radius-md);
+    border-radius: var(--radius-xl, 16px);
   }
 
   .scanner-frame {
@@ -1597,7 +1597,7 @@
 .confidence-display {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
   margin-top: 8px;
 }
 
@@ -1710,7 +1710,7 @@
   display: inline-block;
   font-size: 0.7rem;
   padding: 3px 8px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-weight: 500;
 }
 
@@ -1852,7 +1852,7 @@
   gap: 12px;
   padding: 12px;
   background: var(--bg-light);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   margin-top: 12px;
 }
 
@@ -1906,14 +1906,14 @@
   margin-top: 12px;
   padding: 16px;
   background: var(--bg-light);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
 }
 
 .manual-entry-form .barcode-input {
   flex: 1;
   padding: 12px 16px;
   border: 2px solid var(--border-color);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-size: 1rem;
   font-family: 'Courier New', monospace;
   letter-spacing: 2px;
@@ -2195,7 +2195,7 @@
   text-align: center;
   padding: 16px;
   background: rgba(234, 179, 8, 0.1);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   margin-top: 16px;
 }
 
@@ -2210,7 +2210,7 @@
   color: var(--warning-900, #78350f);
   border: none;
   padding: 10px 20px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-weight: 600;
   cursor: pointer;
 }

--- a/frontend/src/pages/ProfileSettingsPage.css
+++ b/frontend/src/pages/ProfileSettingsPage.css
@@ -46,7 +46,7 @@
   padding: 8px;
   margin: 0 -8px 0 0;
   color: var(--text-primary);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
 }
 .profile-sticky-back:hover {
   background: var(--gray-100);
@@ -261,7 +261,7 @@
 .profile-modal-actions {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 12px;
 }
 
 .profile-modal-actions .btn-primary,
@@ -645,7 +645,7 @@
   margin-bottom: 20px;
   font-size: 1rem;
   border: 1px solid var(--border-color);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   box-sizing: border-box;
 }
 
@@ -792,7 +792,7 @@
   background: linear-gradient(145deg, #f8fafc 0%, #f1f5f9 100%);
   border: 1px solid rgba(226, 232, 240, 0.8);
   border-radius: var(--border-radius-xl);
-  padding: 28px 20px;
+  padding: 24px;
   text-align: center;
   display: flex;
   flex-direction: column;
@@ -980,7 +980,7 @@
   width: 100%;
   padding: 12px 16px;
   border: none;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   background: transparent;
   font-family: inherit;
   font-size: 0.95rem;
@@ -1011,7 +1011,7 @@
   background: var(--bg-white);
   border: 1px solid rgba(226, 232, 240, 0.8);
   border-radius: var(--border-radius-xl);
-  padding: 32px;
+  padding: var(--spacing-lg);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.04);
 }
 
@@ -1091,7 +1091,7 @@
   width: 100%;
   padding: 12px 16px;
   border: 1.5px solid var(--gray-200, #e2e8f0);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-size: 0.95rem;
   color: var(--text-primary);
   background: var(--gray-50, #fafbfc);
@@ -1162,7 +1162,7 @@
   background: var(--primary);
   color: var(--white);
   border: none;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-weight: 600;
   font-size: 1rem;
   cursor: pointer;
@@ -1180,7 +1180,7 @@
 .btn-primary {
   background: linear-gradient(135deg, var(--primary) 0%, var(--primary) 100%);
   border: none;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   padding: 12px 24px;
   font-weight: 600;
   font-size: 0.9rem;
@@ -1198,7 +1198,7 @@
 .btn-secondary {
   background: var(--white);
   border: 1.5px solid var(--gray-200, #e2e8f0);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   padding: 12px 24px;
   font-weight: 500;
   font-size: 0.9rem;
@@ -1216,7 +1216,7 @@
   background: var(--danger);
   color: var(--white);
   border: none;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   padding: 10px 20px;
   font-size: 0.85rem;
   font-weight: 600;
@@ -1271,7 +1271,7 @@
 .profile-settings-page .form-group textarea {
   min-height: 44px;
   padding: var(--spacing-sm) var(--spacing-md);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
 }
 
 .checkbox-grid {
@@ -1285,7 +1285,7 @@
   align-items: center;
   gap: var(--spacing-sm);
   padding: var(--spacing-sm) var(--spacing-md);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   border: 1px solid var(--border);
   background: var(--bg-tertiary);
   font-size: var(--font-size-sm);
@@ -1401,7 +1401,7 @@
   align-items: center;
   gap: 8px;
   padding: 10px 16px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   border: 1.5px solid var(--border-color);
   background: var(--bg-white);
   color: var(--text-primary);
@@ -1527,7 +1527,7 @@
   font-size: 0.95rem;
   font-weight: 500;
   padding: 12px 20px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   cursor: pointer;
   transition: background 0.2s, color 0.2s;
 }

--- a/frontend/src/pages/ProgressTrackingPage.css
+++ b/frontend/src/pages/ProgressTrackingPage.css
@@ -30,7 +30,7 @@
 
 .summary-card {
   background: var(--bg-white);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   padding: var(--spacing-xl) var(--spacing-lg);
   box-shadow: var(--shadow-sm);
   border: 1px solid var(--border);
@@ -92,7 +92,7 @@
   min-height: 44px;
   padding: var(--spacing-sm) var(--spacing-md);
   border: 1px solid var(--border);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   background: var(--bg-secondary);
   color: var(--text-primary);
   font-size: var(--font-size-sm);
@@ -102,7 +102,7 @@
   padding: 8px 12px;
   background: var(--bg-white);
   border: 1px solid var(--border);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   color: var(--text-dark);
   font-size: 0.875rem;
   font-weight: 500;
@@ -187,7 +187,7 @@
 
 .trend-card {
   background: var(--bg-tertiary);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   padding: var(--spacing-lg);
   border: 1px solid var(--border);
 }
@@ -224,7 +224,7 @@
 
 @media (max-width: 768px) {
   .progress-tracking-page {
-    padding: 32px 20px;
+    padding: 24px;
   }
 
   .progress-tracking-page h1 {

--- a/frontend/src/pages/Recommendations.css
+++ b/frontend/src/pages/Recommendations.css
@@ -212,7 +212,7 @@
   left: 12px;
   z-index: 2;
   padding: 6px 12px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   background: linear-gradient(135deg, var(--primary), var(--accent));
   color: var(--white);
   font-size: 0.75rem;
@@ -268,7 +268,7 @@
   color: var(--primary);
   font-weight: 600;
   padding: 8px 16px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   cursor: pointer;
   transition: all 0.2s ease;
 }
@@ -303,7 +303,7 @@
 
 .filter-select {
   padding: 10px 14px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   border: 1px solid var(--border-color);
   background: var(--gray-50);
   color: var(--text-primary);
@@ -439,7 +439,7 @@
   flex-wrap: wrap;
   justify-content: space-between;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
   margin-top: auto;
   padding-top: 16px;
   border-top: 1px solid var(--border-color);
@@ -459,7 +459,7 @@
   padding: 8px 14px;
   background: var(--bg-light, #f1f5f9);
   border: 1px solid var(--border-color, #e2e8f0);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   color: var(--text-primary);
   font-weight: 500;
   font-size: 0.875rem;
@@ -487,7 +487,7 @@
   padding: 10px 20px;
   background: var(--primary);
   border: none;
-  border-radius: var(--border-radius-md); /* Brand guideline: 8px */
+  border-radius: var(--radius-xl, 16px); /* Brand guideline: 8px */
   color: var(--white);
   font-weight: 600;
   font-size: 0.95rem;
@@ -516,7 +516,7 @@
 
 .btn-disabled {
   padding: 10px 20px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   border: 1px solid var(--border-color);
   background: var(--gray-100);
   color: var(--text-muted);

--- a/frontend/src/pages/RoutineBuilderPage.css
+++ b/frontend/src/pages/RoutineBuilderPage.css
@@ -51,7 +51,7 @@
   margin-bottom: var(--spacing-xl);
   background: var(--bg-white);
   padding: var(--spacing-xs);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   box-shadow: var(--shadow-sm);
   border: 1px solid var(--border);
   width: fit-content;
@@ -64,7 +64,7 @@
   padding: var(--spacing-md) var(--spacing-lg);
   min-height: 44px;
   border: none;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-size: var(--font-size-base);
   font-weight: var(--font-weight-medium);
   cursor: pointer;
@@ -134,7 +134,7 @@
 /* Individual Step Card */
 .routine-step {
   background: var(--bg-light);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   padding: var(--spacing-lg) var(--spacing-xl);
   border: 2px solid var(--border);
   transition: all 0.3s ease;
@@ -192,7 +192,7 @@
 .btn-step {
   padding: 8px 16px;
   border: none;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-weight: 500;
   font-size: 0.875rem;
   cursor: pointer;
@@ -224,7 +224,7 @@
   padding: 16px;
   background: var(--bg-light);
   border: 2px dashed var(--border);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   color: var(--primary);
   font-weight: 600;
   font-size: 1rem;
@@ -246,7 +246,7 @@
   background: var(--primary);
   color: var(--white);
   border: none;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-size: 1.1rem;
   font-weight: 600;
   cursor: pointer;
@@ -317,7 +317,7 @@
 .time-btn {
   padding: 12px 24px;
   border: 2px solid var(--border);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   background: var(--bg-white);
   color: var(--text-gray);
   font-size: 1rem;
@@ -386,7 +386,7 @@
   background: var(--primary);
   color: var(--white);
   border: none;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-weight: 500;
   cursor: pointer;
   transition: all 0.2s ease;
@@ -408,7 +408,7 @@
   color: var(--text-muted);
   background: var(--gray-100, #f1f5f9);
   border: 1px dashed var(--border-color);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   cursor: grab;
   flex-shrink: 0;
 }
@@ -455,7 +455,7 @@
 .step-field select {
   padding: 8px 12px;
   border: 1px solid var(--border);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   background: var(--bg-light);
   color: var(--text-dark);
   font-size: 1rem;
@@ -473,7 +473,7 @@
   justify-content: space-between;
   padding: 8px 12px;
   background: var(--bg-light);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
 }
 
 .btn-link {
@@ -593,7 +593,7 @@
   padding: 8px 16px;
   background: var(--bg-light);
   border: 1px solid var(--border);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   color: var(--text-dark);
   font-weight: 500;
   cursor: pointer;
@@ -650,7 +650,7 @@
 .time-setting input[type="time"] {
   padding: 8px 12px;
   border: 1px solid var(--border);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   background: var(--bg-light);
   color: var(--text-dark);
   font-size: 1rem;
@@ -685,7 +685,7 @@
   justify-content: center;
   padding: 8px;
   border: 1px solid var(--border);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   background: var(--bg-light);
   cursor: pointer;
   transition: all 0.2s ease;
@@ -719,7 +719,7 @@
 .routine-actions .btn-primary,
 .routine-actions .btn-secondary {
   padding: 12px 24px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-weight: 600;
   font-size: 1rem;
   cursor: pointer;

--- a/frontend/src/pages/ScanPage.css
+++ b/frontend/src/pages/ScanPage.css
@@ -345,7 +345,7 @@
   margin-bottom: 32px;
   background: var(--bg-light);
   padding: 6px;
-  border-radius: var(--border-radius-md); /* Brand guideline: 8px */
+  border-radius: var(--radius-xl, 16px); /* Brand guideline: 8px */
 }
 
 .mode-btn {
@@ -353,7 +353,7 @@
   padding: 12px 24px; /* Brand guideline: 12px 24px */
   border: none;
   background: transparent;
-  border-radius: var(--border-radius-md); /* Brand guideline: 8px */
+  border-radius: var(--radius-xl, 16px); /* Brand guideline: 8px */
   font-size: 1rem; /* Brand guideline: 16px Body */
   font-weight: 500; /* Brand guideline: Medium */
   color: var(--text-gray);
@@ -919,7 +919,7 @@
   align-items: center;
   transition: all 0.2s ease;
   background: rgba(255, 255, 255, 0.7);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   border: 1px solid transparent;
 }
 
@@ -1011,7 +1011,7 @@
   background: var(--primary); /* Brand teal */
   color: var(--white);
   border: none;
-  border-radius: var(--border-radius-md); /* Brand guideline: 8px */
+  border-radius: var(--radius-xl, 16px); /* Brand guideline: 8px */
   font-size: 1rem;
   font-weight: 600; /* Brand guideline */
   cursor: pointer;
@@ -1037,7 +1037,7 @@
   background: transparent; /* Brand guideline */
   color: var(--primary); /* Brand blue */
   border: 2px solid var(--primary); /* Brand guideline */
-  border-radius: var(--border-radius-md); /* Brand guideline: 8px */
+  border-radius: var(--radius-xl, 16px); /* Brand guideline: 8px */
   font-size: 1rem;
   font-weight: 500;
   cursor: pointer;
@@ -1132,7 +1132,7 @@
   width: 100%;
   height: 10px;
   background: var(--bg-light);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   overflow: hidden;
   margin-bottom: 16px;
   border: 1px solid var(--border);
@@ -1144,7 +1144,7 @@
   height: 100%;
   background: linear-gradient(90deg, var(--primary-500, var(--primary)) 0%, var(--secondary-500, var(--accent)) 50%, var(--primary-400, #818cf8) 100%);
   background-size: 200% 100%;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   transition: width 0.5s cubic-bezier(0.4, 0, 0.2, 1);
   box-shadow: 0 2px 8px rgba(31, 95, 191, 0.3);
   width: var(--progress-width, 0%);

--- a/frontend/src/pages/SkinTypeQuizPage.css
+++ b/frontend/src/pages/SkinTypeQuizPage.css
@@ -8,7 +8,7 @@
 .quiz-question-card { background: var(--bg-secondary, #f6f8fb); border: 1px solid var(--border-color, #e4e9ef); border-radius: 16px; padding: 32px 28px; }
 .quiz-question { font-size: 1.1rem; font-weight: 700; color: var(--text-primary); margin: 0 0 20px; line-height: 1.35; }
 
-.quiz-options { display: flex; flex-direction: column; gap: 10px; }
+.quiz-options { display: flex; flex-direction: column; gap: 12px; }
 .quiz-option {
   display: block; width: 100%; text-align: left;
   padding: 14px 18px; font-size: 0.9rem; font-weight: 500;
@@ -42,7 +42,7 @@
   border-radius: 16px; text-transform: capitalize;
 }
 
-.quiz-result-actions { display: flex; flex-direction: column; gap: 10px; align-items: center; }
+.quiz-result-actions { display: flex; flex-direction: column; gap: 12px; align-items: center; }
 .quiz-result-actions .btn { min-width: 220px; }
 .quiz-retake { font-size: 0.8rem; color: var(--text-muted); background: none; border: none; cursor: pointer; margin-top: 4px; }
 .quiz-retake:hover { color: var(--primary); }

--- a/frontend/src/pages/TodayPage.css
+++ b/frontend/src/pages/TodayPage.css
@@ -38,7 +38,7 @@
   font-size: 1.1rem;
   line-height: 1;
   padding: 4px 6px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   background: var(--bg-secondary);
   border: 1px solid var(--border-color);
 }
@@ -49,7 +49,7 @@
   justify-content: center;
   width: 40px;
   height: 40px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   color: var(--text-secondary);
   background: transparent;
   transition: color 0.2s, background 0.2s;
@@ -240,7 +240,7 @@
 .today-card-title-row {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
   margin-bottom: 12px;
 }
 
@@ -502,7 +502,7 @@
 
 .today-skin-actions {
   display: flex;
-  gap: 10px;
+  gap: 12px;
   margin-top: 14px;
 }
 
@@ -523,7 +523,7 @@
 .today-concerns-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 10px;
+  gap: 12px;
 }
 
 .today-concern-cell {
@@ -774,7 +774,7 @@
   max-width: 200px;
   display: flex;
   flex-direction: column;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   overflow: hidden;
   border: 1px solid var(--border-color);
   background: var(--bg-white, #fff);
@@ -912,7 +912,7 @@
   font-size: 0.75rem;
   font-weight: 600;
   padding: 6px 8px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   text-decoration: none;
   white-space: nowrap;
   transition: background 0.2s, transform 0.1s;
@@ -1003,7 +1003,7 @@
 .today-routine-step-check {
   width: 26px;
   height: 26px;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   border: 2px solid var(--gray-300);
   display: flex;
   align-items: center;
@@ -1102,7 +1102,7 @@
   margin-bottom: 12px;
   padding: 4px;
   background: var(--bg-secondary);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
 }
 
 .today-routine-tab {
@@ -1114,7 +1114,7 @@
   min-height: 44px;
   padding: 10px 12px;
   border: none;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--radius-xl, 16px);
   font-size: 0.9rem;
   font-weight: 600;
   color: var(--text-secondary);
@@ -1306,7 +1306,7 @@
 .today-cta-row {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 12px;
   align-items: center;
 }
 

--- a/frontend/src/pages/VideoTutorialsPage.css
+++ b/frontend/src/pages/VideoTutorialsPage.css
@@ -76,7 +76,7 @@
 
 .tutorial-info {
   display: flex;
-  gap: 10px;
+  gap: 12px;
   margin-bottom: 8px;
   flex-wrap: wrap;
 }


### PR DESCRIPTION
Batch-applied 3 design standards across ALL remaining pages:

1. border-radius: var(--border-radius-md) → var(--radius-xl, 16px) All cards, sections, buttons, inputs now use 16px radius consistently. Previously mixed 8px (--border-radius-md) and 16px (--radius-xl). Applied to: Profile, Analysis Results, My Shelf, Progress, History, Clinical, Comparison, Consent, Contact, Data Export, Device Context, Digital Twin, Email Verification, Favorites, Ingredient Dictionary, Notification Center, Password Reset, Product Compare, Product Details, Product Scanner, Recommendations, Routine Builder, Scan, Today, Common Styles, all 7 Admin pages

2. gap: 10px → 12px 10px is not on the spacing scale (4/8/12/16/20/24). Normalized to 12px. Applied to: About, Admin Products, Consent, Notification Center, Product Details, Product Scanner, Recommendations, Skin Quiz, Today, Video Tutorials

3. padding: 32px → 24px (var(--spacing-lg)) Profile, Analysis Results, Progress — matched card-padding standard.

No color changes. No elements added or removed.

https://claude.ai/code/session_016XpCGMkdoVXBdD3E6dHejV

### Summary

- **What**: One-line summary of the change
- **Why**: Short justification and links to SRS/backlog

### Changes

- Files and modules changed (example: `backend/app/services/auth_service.py`)

### How to run / test locally

```bash
cd backend
pytest -q
```

### Checklist

- [ ] Tests added or updated
- [ ] Documentation updated (`docs/PROJECT_PROGRESS_TRACKER.md` or relevant doc)
- [ ] Env changes documented (`backend/.env.example`)
- [ ] DB migrations added (if schema changes)

### Notes for reviewers

- Any important notes about the change, deployment steps, or potential impacts
