### PR TITLE
fix: final CSS standardization pass — 51 files, 4 phases

### DIFF
--- a/frontend/src/components/AppLayout.css
+++ b/frontend/src/components/AppLayout.css
@@ -126,7 +126,7 @@
 .app-logo {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
   text-decoration: none;
   color: var(--text-primary);
   font-weight: 700;
@@ -136,7 +136,7 @@
 .app-logo-mark {
   width: 38px;
   height: 38px;
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   background: var(--gradient-primary);
   box-shadow: var(--shadow-primary);
   display: flex;
@@ -492,7 +492,7 @@
   align-items: center;
   gap: 8px;
   padding: 12px 20px;
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   font-weight: 600;
   font-size: var(--font-size-sm);
   color: var(--white);
@@ -776,7 +776,7 @@
 .app-nav-mobile-auth {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 12px;
 }
 
 .app-nav-mobile-btn-secondary {
@@ -1134,7 +1134,7 @@
 .app-footer-logo {
   display: inline-flex;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
   text-decoration: none;
   margin-bottom: 20px;
 }
@@ -1167,7 +1167,7 @@
 
 .app-footer-socials {
   display: flex;
-  gap: 10px;
+  gap: 12px;
 }
 
 .app-footer-socials a {
@@ -1521,7 +1521,7 @@
 .app-layout .empty-state {
   background: var(--bg-white);
   border: 1px solid var(--border);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: var(--spacing-xl);
   text-align: center;
   box-shadow: var(--shadow-sm);

--- a/frontend/src/components/ConfirmModal.css
+++ b/frontend/src/components/ConfirmModal.css
@@ -12,7 +12,7 @@
 
 .confirm-modal {
   background: var(--bg-white, #fff);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   box-shadow: var(--shadow-xl);
   max-width: 400px;
   width: 100%;
@@ -28,7 +28,7 @@
 
   .confirm-modal {
     max-width: 100%;
-    border-radius: var(--border-radius-lg) var(--border-radius-lg) 0 0;
+    border-radius: var(--radius-xl, 16px) var(--radius-xl, 16px) 0 0;
     padding: var(--spacing-xl) var(--spacing-lg);
     max-height: 90vh;
     overflow-y: auto;

--- a/frontend/src/components/ConsentModal.css
+++ b/frontend/src/components/ConsentModal.css
@@ -11,7 +11,7 @@
 
 .consent-modal {
   background: var(--bg-white);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   max-width: 700px;
   width: 100%;
   max-height: 90vh;
@@ -30,7 +30,7 @@
     width: 100%;
     max-width: 100%;
     max-height: 95vh;
-    border-radius: var(--border-radius-lg) var(--border-radius-lg) 0 0;
+    border-radius: var(--radius-xl, 16px) var(--radius-xl, 16px) 0 0;
   }
 }
 

--- a/frontend/src/components/EmptyState.css
+++ b/frontend/src/components/EmptyState.css
@@ -2,7 +2,7 @@
   text-align: center;
   padding: var(--spacing-2xl) var(--spacing-lg);
   background: var(--bg-white);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   border: 1px solid var(--border);
   box-shadow: var(--shadow-sm);
   min-height: 50vh;

--- a/frontend/src/components/LoadingScreen.css
+++ b/frontend/src/components/LoadingScreen.css
@@ -21,7 +21,7 @@
   position: relative;
   min-height: 400px;
   width: 100%;
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
 }
 
 .loading-content {

--- a/frontend/src/components/OfflineBanner.css
+++ b/frontend/src/components/OfflineBanner.css
@@ -3,7 +3,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 10px;
+  gap: 12px;
   padding: 12px 16px;
   background: #fef3c7;
   color: #92400e;

--- a/frontend/src/components/Toast.css
+++ b/frontend/src/components/Toast.css
@@ -19,7 +19,7 @@
   align-items: center;
   gap: var(--spacing-sm);
   padding: var(--spacing-md);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   box-shadow: var(--shadow-lg);
   border: 1px solid var(--gray-200);
   background: var(--white);

--- a/frontend/src/components/digital-twin/styles/digital-twin.css
+++ b/frontend/src/components/digital-twin/styles/digital-twin.css
@@ -5,7 +5,7 @@
 }
 
 .dt-container {
-  max-width: 1200px;
+  max-width: 1120px;
   margin: 0 auto;
   display: grid;
   gap: 12px;
@@ -163,7 +163,7 @@
   flex-wrap: wrap;
   justify-content: space-between;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
   margin-bottom: 10px;
 }
 
@@ -183,7 +183,7 @@
 
 .dt-card-body {
   display: grid;
-  gap: 10px;
+  gap: 12px;
 }
 
 /* Guest/error state: feature preview + CTAs to reduce empty viewport */
@@ -253,7 +253,7 @@
 .dt-preview-feature {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
   padding: 12px 16px;
   background: var(--bg-white);
   border: 1px solid var(--border);
@@ -312,7 +312,7 @@
 
 @media (min-width: 600px) {
   .dt-snapshot-grid {
-    gap: 10px;
+    gap: 12px;
   }
 }
 

--- a/frontend/src/components/mobile/MobileInput.css
+++ b/frontend/src/components/mobile/MobileInput.css
@@ -28,7 +28,7 @@
   /* Appearance */
   background: var(--bg-secondary, rgba(0, 0, 0, 0.02));
   border: 1.5px solid transparent;
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   outline: none;
   color: var(--text-primary, #1a1a1a);
   

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1225,7 +1225,7 @@ select {
 
 .card {
   background: var(--bg-white);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   border: 1px solid var(--border);
   box-shadow: var(--shadow-sm);
   transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1),

--- a/frontend/src/pages/AIChatPage.module.css
+++ b/frontend/src/pages/AIChatPage.module.css
@@ -167,7 +167,7 @@
   margin: 0;
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
   letter-spacing: -0.01em;
 }
 

--- a/frontend/src/pages/AboutPage.css
+++ b/frontend/src/pages/AboutPage.css
@@ -49,7 +49,7 @@
   gap: 32px;
   background: var(--bg-white);
   padding: 48px;
-  border-radius: var(--border-radius-lg); /* Brand guideline: 12px for cards */
+  border-radius: var(--radius-xl, 16px); /* Brand guideline: 12px for cards */
   box-shadow: var(--shadow);
   border: 1px solid var(--border);
 }
@@ -68,7 +68,7 @@
 
 .story-card {
   background: var(--bg-white);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   border: 1px solid var(--border);
   box-shadow: var(--shadow);
   padding: 28px;
@@ -113,7 +113,7 @@
 .stat-card {
   background: linear-gradient(180deg, rgba(31, 111, 235, 0.08), rgba(255, 255, 255, 0));
   border: 1px solid rgba(31, 111, 235, 0.18);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: 24px;
   text-align: center;
 }
@@ -139,8 +139,8 @@
 
 .tech-card {
   background: var(--bg-white);
-  border-radius: var(--border-radius-lg);
-  padding: 32px 24px;
+  border-radius: var(--radius-xl, 16px);
+  padding: 24px;
   border: 1px solid var(--border);
   box-shadow: var(--shadow);
   text-align: center;
@@ -153,7 +153,7 @@
 .tech-icon {
   width: 56px;
   height: 56px;
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   background: rgba(31, 111, 235, 0.1);
   color: var(--primary);
   display: flex;
@@ -179,7 +179,7 @@
   gap: 16px;
   padding: 24px;
   background: var(--bg-white);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   border: 1px solid var(--border);
   box-shadow: var(--shadow);
 }
@@ -201,7 +201,7 @@
   width: 48px;
   height: 48px;
   background: rgba(31, 111, 235, 0.1);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -219,7 +219,7 @@
   margin: 0 auto;
   padding: 20px 24px;
   background: var(--bg-white);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   border: 1px solid var(--border);
 }
 .changelog-version {
@@ -272,7 +272,7 @@
   }
 
   .mission-content {
-    padding: 32px 24px;
+    padding: 24px;
   }
 
   .tech-grid,

--- a/frontend/src/pages/AdminContentPage.css
+++ b/frontend/src/pages/AdminContentPage.css
@@ -83,7 +83,7 @@
 .admin-card {
   background: var(--bg-white);
   border: 1px solid var(--border-color, #e2e8f0);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: 16px;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
 }
@@ -129,7 +129,7 @@
 .admin-form-card {
   background: var(--bg-white);
   border: 1px solid var(--border-color, #e2e8f0);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: 24px;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
 }
@@ -255,7 +255,7 @@
   padding: 16px 20px;
   background: var(--bg-white);
   border: 1px solid var(--border-color, #e2e8f0);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
 }
 

--- a/frontend/src/pages/AdminProductsPage.css
+++ b/frontend/src/pages/AdminProductsPage.css
@@ -72,7 +72,7 @@
   border-collapse: collapse;
   background: var(--bg-white);
   border: 1px solid var(--border-color);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   overflow: hidden;
 }
 

--- a/frontend/src/pages/AdminUsersPage.css
+++ b/frontend/src/pages/AdminUsersPage.css
@@ -39,7 +39,7 @@
   border-collapse: collapse;
   background: var(--bg-white);
   border: 1px solid var(--border-color);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   overflow: hidden;
 }
 
@@ -192,7 +192,7 @@
   .admin-user-card {
     background: var(--bg-white);
     border: 1px solid var(--border-color);
-    border-radius: var(--border-radius-lg);
+    border-radius: var(--radius-xl, 16px);
     padding: var(--spacing-lg);
     box-shadow: var(--shadow-sm);
   }

--- a/frontend/src/pages/AnalysisResults.css
+++ b/frontend/src/pages/AnalysisResults.css
@@ -44,7 +44,7 @@
   padding: 48px;
   background: var(--bg-white);
   border: 1px solid var(--border);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   box-shadow: var(--shadow);
 }
 
@@ -53,7 +53,7 @@
   gap: var(--spacing-md);
   align-items: flex-start;
   padding: var(--spacing-lg) var(--spacing-lg);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   border: 1px solid var(--danger-light);
   background: var(--danger-light);
   color: var(--danger);
@@ -103,7 +103,7 @@
   flex-wrap: wrap;
   background: var(--bg-white);
   padding: 24px;
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   box-shadow: var(--shadow);
   border: 1px solid var(--border);
 }
@@ -241,7 +241,7 @@
   flex-wrap: wrap;
   background: var(--bg-white);
   padding: 24px;
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   box-shadow: var(--shadow);
   border: 1px solid var(--border);
   color: var(--text-gray);
@@ -304,7 +304,7 @@
 .result-card {
   background: var(--bg-white);
   border: 1px solid var(--border);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: 24px;
   box-shadow: var(--shadow);
   transition: all 0.3s ease;
@@ -355,7 +355,7 @@
 
 .analysis-image img {
   width: 100%;
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   display: block;
   border: 1px solid var(--border);
   box-shadow: var(--shadow);
@@ -364,7 +364,7 @@
 .analysis-image-fallback {
   align-items: center;
   background: var(--bg-light);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   border: 1px dashed var(--border);
   color: var(--text-gray);
   display: flex;

--- a/frontend/src/pages/AuthPage.css
+++ b/frontend/src/pages/AuthPage.css
@@ -112,7 +112,7 @@
   width: 56px;
   height: 56px;
   background: rgba(255, 255, 255, 0.95);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -313,7 +313,7 @@
 .form-group-inline .checkbox-label {
   display: inline-flex;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
   font-size: 0.9375rem;
   font-weight: 500;
   color: var(--text-secondary, #64748b);
@@ -626,7 +626,7 @@
   background: linear-gradient(135deg, #fef2f2 0%, #fee2e2 100%);
   border: 1px solid var(--danger-200, #fecaca);
   border-left: 4px solid var(--danger);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   margin-bottom: 20px;
   animation: errorSlideIn 0.3s ease-out;
   box-shadow: 0 4px 6px -1px rgba(239, 68, 68, 0.1);

--- a/frontend/src/pages/BlogPage.css
+++ b/frontend/src/pages/BlogPage.css
@@ -49,7 +49,7 @@
 .blog-card {
   background: var(--bg-white);
   border: 1px solid var(--border);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: var(--spacing-lg);
   box-shadow: var(--shadow-sm);
   transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;

--- a/frontend/src/pages/CommonStyles.css
+++ b/frontend/src/pages/CommonStyles.css
@@ -273,7 +273,7 @@
 
 .card {
   background: var(--bg-white);
-  border-radius: var(--card-radius, var(--border-radius-lg));
+  border-radius: var(--card-radius, var(--radius-xl, 16px));
   padding: var(--card-padding, var(--spacing-lg));
   border: 1px solid var(--border);
   box-shadow: var(--card-shadow, var(--shadow-sm));
@@ -296,7 +296,7 @@
   background: linear-gradient(135deg, var(--primary) 0%, var(--accent) 100%);
   color: var(--white);
   padding: var(--spacing-lg);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   text-align: center;
   cursor: pointer;
   min-height: 44px;

--- a/frontend/src/pages/ComparisonPage.css
+++ b/frontend/src/pages/ComparisonPage.css
@@ -86,7 +86,7 @@
 
 .comparison-score-card {
   background: var(--bg-white);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: 24px;
   text-align: center;
   box-shadow: var(--shadow);
@@ -130,7 +130,7 @@
   width: 100%;
   max-width: 400px;
   height: auto;
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   box-shadow: var(--shadow);
   border: 2px solid var(--border);
   object-fit: cover;
@@ -251,7 +251,7 @@
 
 .comparison-chart-placeholder {
   min-height: 260px;
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   border: 1px dashed var(--border);
   background: var(--bg-light);
   color: var(--text-gray);
@@ -299,7 +299,7 @@
 
 @media (max-width: 768px) {
   .comparison-page {
-    padding: 32px 20px;
+    padding: 24px 16px;
   }
 
   .comparison-header h1 {

--- a/frontend/src/pages/ConsentPage.css
+++ b/frontend/src/pages/ConsentPage.css
@@ -43,7 +43,7 @@
   padding: var(--spacing-lg);
   background: var(--bg-white);
   border: 1px solid var(--border);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   transition: all 0.2s ease;
   box-shadow: var(--shadow-sm);
 }

--- a/frontend/src/pages/ContactPage.css
+++ b/frontend/src/pages/ContactPage.css
@@ -36,7 +36,7 @@
 
 .location-section iframe {
   width: 100%;
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
 }
 
 .contact-page .app-page-content.contact-container {
@@ -61,7 +61,7 @@
 .info-card {
   background: var(--bg-white);
   padding: var(--spacing-xl);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   box-shadow: var(--shadow-sm);
   border: 1px solid var(--border);
   text-align: center;
@@ -146,7 +146,7 @@
 .contact-form {
   background: var(--bg-white);
   padding: 40px;
-  border-radius: var(--border-radius-lg); /* Brand guideline: 12px for cards */
+  border-radius: var(--radius-xl, 16px); /* Brand guideline: 12px for cards */
   box-shadow: var(--shadow);
   border: 1px solid var(--border);
 }
@@ -265,7 +265,7 @@
 .faq-accordion-item {
   background: var(--bg-white);
   border: 1px solid var(--border);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   overflow: hidden;
 }
 

--- a/frontend/src/pages/DashboardPage.css
+++ b/frontend/src/pages/DashboardPage.css
@@ -335,7 +335,7 @@
 
 .stat-card {
   background: var(--bg-white);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: var(--spacing-lg);
   box-shadow: var(--shadow-card);
   border: 1px solid var(--gray-100);

--- a/frontend/src/pages/DataExportPage.css
+++ b/frontend/src/pages/DataExportPage.css
@@ -129,7 +129,7 @@
   padding: 24px;
   background: var(--bg-light);
   border: 2px solid var(--border);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   cursor: pointer;
   transition: all 0.2s ease;
   text-align: center;

--- a/frontend/src/pages/DeviceContextPage.css
+++ b/frontend/src/pages/DeviceContextPage.css
@@ -42,7 +42,7 @@
   padding: 16px;
   margin: 16px;
   background: var(--bg-white);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   border: 1px solid var(--border-color);
 }
 
@@ -89,7 +89,7 @@
 
 .device-ctx-section {
   background: var(--bg-white);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: 16px;
   margin-bottom: 12px;
   border: 1px solid var(--border-color);

--- a/frontend/src/pages/DigitalTwinTimelinePage.css
+++ b/frontend/src/pages/DigitalTwinTimelinePage.css
@@ -57,7 +57,7 @@
 
 .twin-explainer-card {
   background: var(--bg-white);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: var(--spacing-lg);
   border: 1px solid var(--border);
   box-shadow: var(--shadow-sm);
@@ -83,7 +83,7 @@
 
 .summary-card {
   background: var(--bg-white);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: 24px;
   box-shadow: var(--shadow);
   border: 1px solid var(--border);
@@ -106,7 +106,7 @@
   width: 56px;
   height: 56px;
   background: var(--primary-light, rgba(31, 111, 235, 0.1));
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   color: var(--primary);
   flex-shrink: 0;
 }
@@ -169,8 +169,8 @@
 
 .card {
   background: var(--bg-white);
-  border-radius: var(--border-radius-lg);
-  padding: 32px;
+  border-radius: var(--radius-xl, 16px);
+  padding: 24px;
   box-shadow: var(--shadow);
   border: 1px solid var(--border);
   margin-bottom: 32px;
@@ -244,7 +244,7 @@
 .snapshot-item {
   cursor: pointer;
   border: 2px solid var(--border);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   overflow: hidden;
   transition: all 0.3s ease;
   background: var(--bg-white);
@@ -323,14 +323,14 @@
 }
 
 .detail-image {
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   overflow: hidden;
 }
 
 .detail-image img {
   width: 100%;
   height: auto;
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   box-shadow: var(--shadow);
 }
 
@@ -411,7 +411,7 @@
   max-width: 400px;
   aspect-ratio: 4 / 5;
   object-fit: cover;
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   box-shadow: var(--shadow);
   margin: 16px 0;
 }
@@ -583,7 +583,7 @@
   text-align: center;
   padding: 24px;
   background: linear-gradient(135deg, var(--primary) 0%, var(--primary-dark) 100%);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   color: var(--white);
 }
 

--- a/frontend/src/pages/EmailVerificationPage.css
+++ b/frontend/src/pages/EmailVerificationPage.css
@@ -11,7 +11,7 @@
   width: 100%;
   max-width: 480px;
   background: var(--bg-white);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: var(--spacing-xl);
   box-shadow: var(--shadow-xl);
   border: 1px solid var(--border-color);
@@ -74,7 +74,7 @@
   text-align: center;
   padding: 16px;
   background: rgba(59, 130, 246, 0.05);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   border: 1px solid rgba(59, 130, 246, 0.2);
 }
 
@@ -94,7 +94,7 @@
   color: var(--accent-primary);
   border: 1px solid var(--accent-primary);
   padding: 12px 24px;
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   font-weight: 600;
   cursor: pointer;
   transition: all 0.2s ease;
@@ -112,7 +112,7 @@
 .dev-token {
   padding: 12px;
   background: rgba(15, 23, 42, 0.04);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   font-size: 0.85rem;
   display: flex;
   flex-direction: column;

--- a/frontend/src/pages/GoogleCallbackPage.css
+++ b/frontend/src/pages/GoogleCallbackPage.css
@@ -11,7 +11,7 @@
 
 .callback-container {
   background: var(--bg-white);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: var(--spacing-2xl);
   text-align: center;
   max-width: 400px;

--- a/frontend/src/pages/HistoryPage.css
+++ b/frontend/src/pages/HistoryPage.css
@@ -129,7 +129,7 @@
   margin-bottom: 24px;
   padding: 16px;
   background: var(--bg-white);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   border: 1px solid var(--border);
   box-shadow: var(--shadow-sm);
 }
@@ -237,7 +237,7 @@
   width: 64px;
   height: 64px;
   background: var(--bg-light);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/frontend/src/pages/HomePage.css
+++ b/frontend/src/pages/HomePage.css
@@ -743,7 +743,7 @@
   margin: 0 0 24px;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 12px;
 }
 
 .skin-expert-features li {

--- a/frontend/src/pages/IngredientDictionaryPage.css
+++ b/frontend/src/pages/IngredientDictionaryPage.css
@@ -123,7 +123,7 @@
 
 .ingredient-card {
   background: var(--bg-white);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: var(--spacing-lg);
   border: 1px solid var(--border);
   box-shadow: var(--shadow-sm);

--- a/frontend/src/pages/MePage.css
+++ b/frontend/src/pages/MePage.css
@@ -190,7 +190,7 @@
 
 .me-list {
   background: var(--bg-white);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   overflow: hidden;
   box-shadow: var(--shadow-card);
   border: 1px solid var(--gray-100);

--- a/frontend/src/pages/MyShelfPage.css
+++ b/frontend/src/pages/MyShelfPage.css
@@ -141,7 +141,7 @@
   gap: 8px;
   padding: 12px;
   background: var(--bg-white);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   border: 1px solid rgba(245, 158, 11, 0.2);
   cursor: pointer;
   text-align: center;
@@ -248,7 +248,7 @@
   line-height: 1.5;
   padding: 12px;
   background: var(--gray-50);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
 }
 
 .myshelf-tip strong {
@@ -270,7 +270,7 @@
   align-items: center;
   background: var(--bg-white);
   border: 1px solid var(--border-color);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: 0 16px;
   min-height: 48px;
   transition: border-color 0.2s, box-shadow 0.2s;
@@ -402,7 +402,7 @@
   gap: 8px;
   padding: 0 20px;
   min-height: 44px;
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   border: none;
   background: linear-gradient(135deg, var(--primary) 0%, var(--accent) 100%);
   color: var(--white);
@@ -436,7 +436,7 @@
 .myshelf-sort-select {
   padding: 10px 14px;
   border: 1px solid var(--border-color);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   background: var(--bg-white);
   font-size: 0.875rem;
   color: var(--text-primary);
@@ -700,7 +700,7 @@
   border: none;
   background: transparent;
   color: var(--text-muted);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   cursor: pointer;
 }
 
@@ -717,7 +717,7 @@
   min-width: 180px;
   background: var(--bg-white);
   border: 1px solid var(--border-color);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   box-shadow: 0 12px 40px rgba(0, 0, 0, 0.12);
   z-index: 20;
   padding: 8px;
@@ -765,7 +765,7 @@
   min-height: 44px;
   padding: 10px 14px;
   border: 1px solid var(--border-color);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   background: var(--bg-white);
   font-size: 0.875rem;
   color: var(--text-primary);
@@ -783,7 +783,7 @@
   background: transparent;
   color: var(--danger);
   border: 1px solid var(--danger);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   font-weight: 600;
   font-size: 0.875rem;
   cursor: pointer;
@@ -831,7 +831,7 @@
 .repurchase-btn {
   background: var(--gray-100);
   border: 1px solid var(--border-color);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: 6px 12px;
   font-size: 0.8125rem;
   cursor: pointer;
@@ -926,7 +926,7 @@
     height: 72px;
     aspect-ratio: unset;
     margin: 12px 0 12px 12px;
-    border-radius: var(--border-radius-lg);
+    border-radius: var(--radius-xl, 16px);
     flex-shrink: 0;
   }
 

--- a/frontend/src/pages/NotFoundPage.css
+++ b/frontend/src/pages/NotFoundPage.css
@@ -57,7 +57,7 @@
   width: 100%;
   min-height: 48px;
   padding: 12px 16px;
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   font-size: 1rem;
   font-weight: 600;
   text-decoration: none;

--- a/frontend/src/pages/NotificationCenterPage.css
+++ b/frontend/src/pages/NotificationCenterPage.css
@@ -238,7 +238,7 @@
   width: 48px;
   height: 48px;
   background: var(--bg-tertiary);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   flex-shrink: 0;
   color: var(--notification-color, var(--primary));
 }
@@ -322,7 +322,7 @@
   text-align: center;
   padding: 64px 32px;
   background: var(--white);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   border: 2px dashed var(--border-color);
 }
 

--- a/frontend/src/pages/PrivacyPage.css
+++ b/frontend/src/pages/PrivacyPage.css
@@ -48,7 +48,7 @@
   margin: 0 auto var(--spacing-lg);
   padding: var(--spacing-lg) var(--spacing-lg);
   background: var(--bg-white);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   border: 1px solid var(--border);
   box-shadow: var(--shadow-sm);
 }
@@ -80,7 +80,7 @@
 .privacy-section {
   background: var(--bg-white);
   padding: 40px;
-  border-radius: var(--border-radius-lg); /* Brand guideline: 12px for cards */
+  border-radius: var(--radius-xl, 16px); /* Brand guideline: 12px for cards */
   box-shadow: var(--shadow);
   border: 1px solid var(--border);
   margin-bottom: 32px;

--- a/frontend/src/pages/ProductComparePage.css
+++ b/frontend/src/pages/ProductComparePage.css
@@ -61,7 +61,7 @@
 .compare-card {
   background: var(--bg-white);
   border: 1px solid var(--border);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: var(--spacing-lg);
   display: flex;
   flex-direction: column;
@@ -70,7 +70,7 @@
 
 .compare-card-media {
   width: 100%;
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   background: var(--bg-light);
   border: 1px solid var(--border);
   overflow: hidden;

--- a/frontend/src/pages/ProductDetailsPage.css
+++ b/frontend/src/pages/ProductDetailsPage.css
@@ -125,7 +125,7 @@
 .product-image-section {
   background: var(--white);
   border: 1px solid var(--border-color);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: 24px;
   box-shadow: var(--shadow-sm);
 }
@@ -224,7 +224,7 @@
   height: 260px;
   color: var(--text-muted);
   background: linear-gradient(145deg, var(--bg-tertiary) 0%, var(--primary-light) 50%, var(--accent-light) 100%);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   border: 1px dashed var(--border-color);
 }
 
@@ -262,7 +262,7 @@
 .from-catalog-badge {
   display: inline-block;
   padding: 2px 10px;
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   font-size: 0.8rem;
   font-weight: 500;
   background: rgba(34, 197, 94, 0.15);
@@ -400,7 +400,7 @@
   margin: 0 auto var(--spacing-3xl);
   background: var(--bg-white);
   border: 1px solid var(--border);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   box-shadow: var(--shadow-sm);
 }
 
@@ -762,7 +762,7 @@
   padding: var(--spacing-2xl) var(--spacing-xl);
   color: var(--text-secondary);
   background: var(--bg-tertiary);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   border: 1px solid var(--border-color);
 }
 
@@ -799,7 +799,7 @@
 
 @media (max-width: 768px) {
   .product-details-page {
-    padding: 32px 20px;
+    padding: 24px 16px;
   }
 
   .back-button {
@@ -1035,7 +1035,7 @@
 .match-for-you-bullets {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px 16px;
+  gap: 12px 16px;
   font-size: 0.9rem;
 }
 .match-bullet.ok { color: var(--success, var(--success)); }
@@ -1059,7 +1059,7 @@
 
 .safety-rating-card {
   background: var(--bg-light);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: var(--spacing-md);
 }
 
@@ -1280,7 +1280,7 @@
 .usage-info-card {
   background: linear-gradient(135deg, var(--primary-light), var(--accent-light));
   border: 1px solid var(--border-color);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: var(--spacing-lg);
   margin-bottom: var(--spacing-lg);
   box-shadow: var(--shadow-sm);
@@ -1344,7 +1344,7 @@
 /* Task 239-240: Pairing Section */
 .pairing-section {
   background: var(--bg-secondary);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: 16px;
 }
 
@@ -1382,7 +1382,7 @@
 .no-ingredients-message {
   padding: 24px;
   background: var(--bg-secondary);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   text-align: center;
 }
 

--- a/frontend/src/pages/ProductScannerPage.css
+++ b/frontend/src/pages/ProductScannerPage.css
@@ -92,7 +92,7 @@
   min-width: 0;
   background: var(--bg-white);
   border: 2px solid var(--border);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   font-size: 1rem;
   font-weight: 600;
   color: var(--text-gray);
@@ -173,7 +173,7 @@
   max-width: 600px;
   margin: 0 auto;
   min-height: 280px;
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   overflow: hidden;
   background: var(--bg-tertiary, #f1f5f9);
   border: 1px solid var(--border);
@@ -292,7 +292,7 @@
 .photo-tips {
   text-align: left;
   background: var(--bg-light);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: 20px;
 }
 
@@ -313,7 +313,7 @@
 /* Processing State */
 .processing-card {
   background: var(--bg-white);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: 64px 32px;
   text-align: center;
   box-shadow: var(--shadow);
@@ -430,7 +430,7 @@
   width: 56px;
   height: 56px;
   background: rgba(31, 111, 235, 0.1);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -474,8 +474,8 @@
 
 .scanner-card {
   background: var(--bg-white);
-  border-radius: var(--border-radius-lg);
-  padding: 32px;
+  border-radius: var(--radius-xl, 16px);
+  padding: 24px;
   box-shadow: var(--shadow);
   border: 1px solid var(--border);
 }
@@ -514,7 +514,7 @@
   width: 100%;
   max-width: 600px;
   margin: 0 auto;
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   overflow: hidden;
   background: #000;
 }
@@ -541,7 +541,7 @@
   width: 80%;
   height: 40%;
   border: 3px solid var(--primary);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.5);
 }
 
@@ -562,7 +562,7 @@
   text-align: center;
   padding: 64px 32px;
   background: var(--bg-light);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   border: 2px dashed var(--border);
   color: var(--text-gray);
 }
@@ -607,7 +607,7 @@
   margin-top: 48px;
   background: var(--bg-white);
   border-radius: var(--border-radius-xl);
-  padding: 32px;
+  padding: 24px;
   border: 1px solid var(--border);
   box-shadow: var(--shadow);
 }
@@ -626,7 +626,7 @@
 
 .guide-card {
   background: var(--bg-light);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: 20px;
   border: 1px solid var(--border);
 }
@@ -653,7 +653,7 @@
 .example-card {
   background: var(--bg-white);
   border: 1px dashed rgba(31, 111, 235, 0.35);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: 20px;
 }
 
@@ -671,7 +671,7 @@
 
 .error-card {
   background: var(--bg-white);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: 48px;
   text-align: center;
   box-shadow: var(--shadow);
@@ -701,7 +701,7 @@
 
 .product-info-card {
   background: var(--bg-white);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: var(--spacing-xl);
   box-shadow: var(--shadow-md);
   border: 1px solid var(--border);
@@ -758,7 +758,7 @@
 }
 
 .product-image {
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   overflow: hidden;
   box-shadow: var(--shadow);
   background: var(--bg-white);
@@ -808,7 +808,7 @@
 
 /* Your Skin Match card – personalized match % after scan */
 .skin-match-card {
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: 20px;
   margin-bottom: 24px;
   border: 1px solid var(--border);
@@ -860,7 +860,7 @@
   margin-top: 16px;
   padding: 16px;
   background: var(--bg-secondary);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   border: 1px solid var(--border-color);
 }
 .how-to-use-title {
@@ -892,7 +892,7 @@
   padding: 16px;
   background: rgba(245, 158, 11, 0.1);
   border: 1px solid rgba(245, 158, 11, 0.4);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
 }
 .ingredient-conflict-title {
   margin: 0 0 8px 0;
@@ -998,7 +998,7 @@
 
 .rating-card {
   background: var(--bg-light);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: 20px;
 }
 
@@ -1321,7 +1321,7 @@
 .warnings-section {
   background: rgba(249, 115, 22, 0.1);
   border: 1px solid var(--secondary);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: 20px;
   margin-bottom: 32px;
 }
@@ -1659,7 +1659,7 @@
 
 .history-card {
   background: var(--white);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   overflow: hidden;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
@@ -1775,7 +1775,7 @@
   width: 280px;
   height: 160px;
   border: 2px dashed rgba(255, 255, 255, 0.5);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
 }
 
 .scan-zone-guide .corner {
@@ -2057,7 +2057,7 @@
   gap: 8px;
   width: 100%;
   padding: 24px;
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   font-size: 1rem;
   font-weight: 600;
   cursor: pointer;
@@ -2123,9 +2123,9 @@
   align-items: center;
   justify-content: center;
   gap: 12px;
-  padding: 32px;
+  padding: 24px;
   border: 2px dashed var(--border-color);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   background: var(--bg-light);
   color: var(--text-muted);
   transition: all 0.2s ease;

--- a/frontend/src/pages/ProfileSettingsPage.css
+++ b/frontend/src/pages/ProfileSettingsPage.css
@@ -563,7 +563,7 @@
   padding: 14px 20px;
   background: transparent;
   border: 1px solid var(--danger);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   color: var(--danger);
   font-size: 1rem;
   font-weight: 600;
@@ -583,7 +583,7 @@
   margin-top: 10px;
   background: transparent;
   border: none;
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   color: var(--text-muted);
   font-size: 0.9rem;
   text-align: center;
@@ -858,7 +858,7 @@
   justify-content: center;
   padding: 16px 12px;
   background: linear-gradient(145deg, #f8fafc 0%, #f1f5f9 100%);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   gap: 6px;
   text-align: center;
 }
@@ -919,7 +919,7 @@
   padding: 14px 18px;
   border: none;
   background: transparent;
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   cursor: pointer;
   font-size: 0.95rem;
   font-weight: 600;
@@ -1438,7 +1438,7 @@
 .privacy-info {
   margin-top: 16px;
   background: var(--bg-tertiary);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: 16px;
 }
 
@@ -1457,7 +1457,7 @@
 .stats-grid .stat-card {
   background: var(--bg-white);
   border: 1px solid var(--border-color);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: 20px;
   text-align: center;
   transition: box-shadow 0.2s ease;
@@ -1480,7 +1480,7 @@
 .comparison-placeholder {
   background: var(--bg-tertiary);
   border: 1px solid var(--border-color);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: 16px;
 }
 
@@ -1690,7 +1690,7 @@
   }
 
   .settings-group {
-    border-radius: var(--border-radius-lg);
+    border-radius: var(--radius-xl, 16px);
   }
 
   .settings-item,
@@ -1781,7 +1781,7 @@
   }
   .quick-stat {
     padding: 12px;
-    border-radius: var(--border-radius-lg);
+    border-radius: var(--radius-xl, 16px);
   }
   .quick-stat-value {
     font-size: 1.25rem;
@@ -1839,7 +1839,7 @@
 
   .section-card {
     padding: 16px;
-    border-radius: var(--border-radius-lg);
+    border-radius: var(--radius-xl, 16px);
   }
   .section-card-header h2 {
     font-size: 1.125rem;

--- a/frontend/src/pages/ProgressTrackingPage.css
+++ b/frontend/src/pages/ProgressTrackingPage.css
@@ -59,7 +59,7 @@
 
 .chart-section {
   background: var(--bg-white);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: 20px;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
   border: 1px solid var(--border-color);
@@ -132,7 +132,7 @@
 
 .chart-placeholder {
   min-height: 320px;
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   border: 1px dashed var(--border);
   background: var(--bg-light);
   color: var(--text-gray);

--- a/frontend/src/pages/Recommendations.css
+++ b/frontend/src/pages/Recommendations.css
@@ -153,7 +153,7 @@
 .recommendations-geo-banner {
   background: linear-gradient(135deg, rgba(37, 99, 235, 0.08), rgba(124, 58, 237, 0.06));
   border: 1px solid var(--border-color);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: 14px 18px;
   margin-bottom: 20px;
 }
@@ -563,7 +563,7 @@
   padding: 16px 20px;
   background: var(--bg-white);
   border: 1px solid var(--border-color);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   box-shadow: var(--shadow-sm);
   display: flex;
   align-items: center;
@@ -630,7 +630,7 @@
   text-align: center;
   padding: 80px 40px;
   background: var(--white);
-  border-radius: var(--border-radius-lg); /* Brand guideline: 12px for cards */
+  border-radius: var(--radius-xl, 16px); /* Brand guideline: 12px for cards */
   box-shadow: var(--shadow-sm);
   border: 1px solid var(--border-color);
 }

--- a/frontend/src/pages/RoutineBuilderPage.css
+++ b/frontend/src/pages/RoutineBuilderPage.css
@@ -91,7 +91,7 @@
 /* Main Routine Builder Card */
 .routine-builder {
   background: var(--bg-white);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: var(--spacing-xl);
   box-shadow: var(--shadow-sm);
   border: 1px solid var(--border);
@@ -290,7 +290,7 @@
   padding: 16px;
   background: linear-gradient(135deg, rgba(31, 95, 191, 0.08) 0%, rgba(124, 58, 237, 0.06) 100%);
   border: 1px solid rgba(31, 95, 191, 0.25);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
 }
 .routine-add-product-content {
   display: flex;
@@ -347,7 +347,7 @@
 .suggestion-card {
   background: var(--bg-white);
   border: 1px solid var(--border);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: 20px;
   display: flex;
   align-items: center;
@@ -426,7 +426,7 @@
 .step-card {
   background: var(--bg-white);
   border: 2px solid var(--border);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: 20px;
   display: grid;
   grid-template-columns: 36px 50px 1fr auto;
@@ -522,7 +522,7 @@
 /* Routine Tips */
 .routine-tips {
   background: var(--bg-white);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: 24px;
   margin: 32px 0;
   border: 1px solid var(--border);
@@ -559,7 +559,7 @@
 /* Routine Reminders */
 .routine-reminders {
   background: var(--bg-white);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: 24px;
   margin: 32px 0;
   border: 1px solid var(--border);
@@ -755,7 +755,7 @@
   text-align: center;
   padding: 48px 24px;
   background: var(--bg-white);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   border: 2px dashed var(--border);
 }
 

--- a/frontend/src/pages/ScanPage.css
+++ b/frontend/src/pages/ScanPage.css
@@ -237,7 +237,7 @@
 
 .scan-content {
   background: var(--bg-white);
-  border-radius: var(--border-radius-lg); /* Brand guideline: 12px for cards */
+  border-radius: var(--radius-xl, 16px); /* Brand guideline: 12px for cards */
   padding: 32px 24px;
   min-height: min(560px, 58vh);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1); /* Brand guideline */
@@ -286,7 +286,7 @@
   margin-top: 16px;
   padding: 12px 16px;
   background: var(--bg-light);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   max-width: 520px;
   margin-left: auto;
   margin-right: auto;
@@ -393,7 +393,7 @@
   max-width: 650px;
   background: rgba(15, 23, 42, 0.06);
   border: 1px solid rgba(15, 23, 42, 0.12);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: 10px 14px;
   font-weight: 600;
   color: var(--text-dark);
@@ -409,7 +409,7 @@
   width: 100%;
   max-width: 650px;
   margin: 0 auto 24px;
-  border-radius: var(--border-radius-lg); /* Brand guideline: 12px for cards */
+  border-radius: var(--radius-xl, 16px); /* Brand guideline: 12px for cards */
   overflow: hidden;
   background: #000;
   aspect-ratio: 4/3;
@@ -550,7 +550,7 @@
   position: absolute;
   inset: 14px;
   border: none;
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   box-shadow: inset 0 0 30px rgba(31, 95, 191, 0.12);
   z-index: 1;
 }
@@ -899,7 +899,7 @@
   line-height: 1.4;
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
 }
 
 .scan-tips ul {
@@ -1282,7 +1282,7 @@
   margin: 0 auto;
   background: var(--bg-white);
   padding: 48px;
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   border: 1px solid var(--border);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
   animation: slideInUp 0.5s cubic-bezier(0.16, 1, 0.3, 1) 0.1s both;
@@ -1334,7 +1334,7 @@
   border-left: 4px solid var(--error-500, var(--danger));
   color: var(--error-600, var(--danger));
   padding: 20px 24px;
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   margin-top: 24px;
   display: flex;
   align-items: flex-start;
@@ -1371,7 +1371,7 @@
   border-left: 4px solid var(--primary);
   color: var(--primary-700, #1d4ed8);
   padding: 16px 20px;
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   margin-top: 20px;
   display: flex;
   align-items: flex-start;
@@ -2081,7 +2081,7 @@
 .trend-sparkline-meta {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
 }
 
 .trend-sparkline-badge {

--- a/frontend/src/pages/SkinGoalsPage.css
+++ b/frontend/src/pages/SkinGoalsPage.css
@@ -55,7 +55,7 @@
   gap: 12px;
   padding: 14px 16px;
   background: var(--bg-white);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   border: 2px solid var(--border-color);
   cursor: pointer;
   color: var(--text-primary);

--- a/frontend/src/pages/SkinTypeGuidePage.css
+++ b/frontend/src/pages/SkinTypeGuidePage.css
@@ -42,7 +42,7 @@
 
 .skin-type-card {
   background: var(--bg-white);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: var(--spacing-lg);
   border: 1px solid var(--border);
   box-shadow: var(--shadow-sm);
@@ -81,7 +81,7 @@
 .skin-type-tips {
   margin-top: 32px;
   background: var(--bg-white);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: 20px;
   border: 1px solid var(--border);
   box-shadow: var(--shadow);
@@ -100,7 +100,7 @@
   margin-top: 32px;
   padding: 20px;
   background: var(--bg-light);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   border: 1px solid var(--border);
 }
 .skin-type-summary h2 {

--- a/frontend/src/pages/TermsPage.css
+++ b/frontend/src/pages/TermsPage.css
@@ -48,7 +48,7 @@
   margin: 0 auto var(--spacing-lg);
   padding: var(--spacing-lg) var(--spacing-lg);
   background: var(--bg-white);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   border: 1px solid var(--border);
   box-shadow: var(--shadow-sm);
 }
@@ -85,7 +85,7 @@
 .terms-section {
   background: var(--bg-white);
   padding: 40px;
-  border-radius: var(--border-radius-lg); /* Brand guideline: 12px for cards */
+  border-radius: var(--radius-xl, 16px); /* Brand guideline: 12px for cards */
   box-shadow: var(--shadow);
   border: 1px solid var(--border);
   margin-bottom: 32px;

--- a/frontend/src/pages/TodayPage.css
+++ b/frontend/src/pages/TodayPage.css
@@ -190,7 +190,7 @@
   min-width: 72px;
   padding: 12px;
   background: var(--bg-secondary);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
 }
 
 .today-progress-label {
@@ -533,7 +533,7 @@
   justify-content: center;
   min-height: 72px;
   padding: 12px;
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   text-align: center;
   border: 1px solid var(--border-color);
   background: var(--bg-secondary);
@@ -619,7 +619,7 @@
   display: flex;
   flex-direction: column;
   gap: 14px;
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   overflow: hidden;
   border: 1px solid var(--border-color);
   background: var(--bg-secondary);
@@ -711,7 +711,7 @@
 
 /* Recommended for you – section container */
 .today-card-toppick {
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.8) 0%, var(--bg-secondary) 100%);
   border: 1px solid var(--border-color);
 }
@@ -1166,7 +1166,7 @@
   width: min(160px, 48vw);
   min-height: 44px;
   padding: 12px 10px;
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   background: var(--bg-secondary);
   border: 1px solid var(--border-color);
   cursor: pointer;
@@ -1270,7 +1270,7 @@
   padding: 14px;
   background: rgba(124, 58, 237, 0.08);
   border: 1px solid rgba(124, 58, 237, 0.2);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
 }
 
 .today-twin-intro-text {

--- a/frontend/src/pages/VideoTutorialsPage.css
+++ b/frontend/src/pages/VideoTutorialsPage.css
@@ -42,7 +42,7 @@
 
 .video-card {
   background: var(--bg-white);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   padding: 20px;
   border: 1px solid var(--border);
   box-shadow: var(--shadow);
@@ -51,7 +51,7 @@
 .video-thumb-wrap {
   position: relative;
   margin-bottom: 12px;
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   overflow: hidden;
 }
 
@@ -61,7 +61,7 @@
   padding-bottom: 56.25%;
   height: 0;
   margin-bottom: 12px;
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   overflow: hidden;
 }
 
@@ -71,7 +71,7 @@
   left: 0;
   width: 100%;
   height: 100%;
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
 }
 
 .tutorial-info {
@@ -92,7 +92,7 @@
   aspect-ratio: 16 / 9;
   background: linear-gradient(135deg, rgba(31, 111, 235, 0.12) 0%, rgba(31, 111, 235, 0.06) 100%);
   border: 1px solid rgba(31, 111, 235, 0.25);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--radius-xl, 16px);
   display: flex;
   align-items: flex-end;
   justify-content: flex-end;

--- a/frontend/src/ui/Checkbox/Checkbox.module.css
+++ b/frontend/src/ui/Checkbox/Checkbox.module.css
@@ -1,7 +1,7 @@
 .wrapper {
   display: inline-flex;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
   /* 44px minimum touch target */

--- a/frontend/src/ui/DropdownMenu/DropdownMenu.module.css
+++ b/frontend/src/ui/DropdownMenu/DropdownMenu.module.css
@@ -33,7 +33,7 @@
 .menuItem {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
   width: 100%;
   min-height: 40px;
   padding: 8px 12px;


### PR DESCRIPTION
Phase 1: border-radius: var(--border-radius-lg) → var(--radius-xl, 16px)
  150+ instances across 45 files. All cards, sections, inputs, dropdowns,
  modals now use consistent 16px radius.

Phase 2: gap: 10px → 12px
  17 instances across 10 files. 10px was off the spacing scale (4/8/12/16/20/24).
  Applied to: ProductDetails, AIChatPage, AuthPage, ScanPage, HomePage,
  AppLayout, OfflineBanner, digital-twin, DropdownMenu, Checkbox

Phase 3: padding: 32px → 24px
  8 instances across 5 files. Card/section padding standardized.
  ProductScanner (3), DigitalTwinTimeline (1), Comparison (1),
  About (2), ProductDetails (1)

Phase 4: max-width: 1200px → 1120px
  1 instance in digital-twin.css. All content now 1120px.

Remaining zero-count verification:
- border-radius-lg: 0 remaining
- gap: 10px: 0 remaining
- max-width: 1200px: 0 remaining
- max-width: 1080px: 0 remaining

No color changes.

https://claude.ai/code/session_016XpCGMkdoVXBdD3E6dHejV

### Summary

- **What**: One-line summary of the change
- **Why**: Short justification and links to SRS/backlog

### Changes

- Files and modules changed (example: `backend/app/services/auth_service.py`)

### How to run / test locally

```bash
cd backend
pytest -q
```

### Checklist

- [ ] Tests added or updated
- [ ] Documentation updated (`docs/PROJECT_PROGRESS_TRACKER.md` or relevant doc)
- [ ] Env changes documented (`backend/.env.example`)
- [ ] DB migrations added (if schema changes)

### Notes for reviewers

- Any important notes about the change, deployment steps, or potential impacts
