### PR TITLE
fix: profile link not working — dropdown wasn't closing on click

### DIFF
--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -270,11 +270,11 @@ const displayName = nameParts.length > 1
                           </div>
                         </div>
                         <div className="app-nav-dropdown-divider" />
-                        <Link to="/profile" className="app-nav-dropdown-item" onMouseEnter={() => { void import('../pages/ProfileSettingsPage'); }}>
+                        <Link to="/profile" className="app-nav-dropdown-item" onClick={() => setUserDropdownOpen(false)} onMouseEnter={() => { void import('../pages/ProfileSettingsPage'); }}>
                           <IconUser size={18} strokeWidth={2} />
                           <span>My Profile</span>
                         </Link>
-                        <Link to="/profile?tab=settings" className="app-nav-dropdown-item" onMouseEnter={() => { void import('../pages/ProfileSettingsPage'); }}>
+                        <Link to="/profile?tab=settings" className="app-nav-dropdown-item" onClick={() => setUserDropdownOpen(false)} onMouseEnter={() => { void import('../pages/ProfileSettingsPage'); }}>
                           <IconSettings size={18} strokeWidth={2} />
                           <span>Settings</span>
                         </Link>


### PR DESCRIPTION
Profile and Settings links in user dropdown had no onClick handler to close the dropdown. User clicks "My Profile" but dropdown stays open, blocking navigation.

Fix: Added onClick={() => setUserDropdownOpen(false)} to both profile and settings Link components in the user dropdown menu.

https://claude.ai/code/session_016XpCGMkdoVXBdD3E6dHejV

### Summary

- **What**: One-line summary of the change
- **Why**: Short justification and links to SRS/backlog

### Changes

- Files and modules changed (example: `backend/app/services/auth_service.py`)

### How to run / test locally

```bash
cd backend
pytest -q
```

### Checklist

- [ ] Tests added or updated
- [ ] Documentation updated (`docs/PROJECT_PROGRESS_TRACKER.md` or relevant doc)
- [ ] Env changes documented (`backend/.env.example`)
- [ ] DB migrations added (if schema changes)

### Notes for reviewers

- Any important notes about the change, deployment steps, or potential impacts
