### PR TITLE
fix: chat page completely unstyled — convert from CSS modules to regu…

### DIFF
--- a/frontend/src/pages/AIChatPage.css
+++ b/frontend/src/pages/AIChatPage.css
@@ -1,0 +1,295 @@
+/* ===== AI Chat Page =====
+   Full-height chat interface within AppLayout.
+   Works WITH app-main constraints, no negative margins.
+   Matches Pellicura design language.
+===== */
+
+/* ===== Page Layout ===== */
+.chat-page {
+  display: flex;
+  flex: 1;
+  height: 100%;
+  overflow: hidden;
+  background: var(--bg-light, #f6f8fb);
+}
+
+/* ===== Sidebar ===== */
+.chat-sidebar {
+  width: 280px;
+  flex-shrink: 0;
+  height: 100%;
+  overflow: hidden;
+  border-right: 1px solid var(--border-color);
+  background: var(--bg-primary);
+}
+
+@media (max-width: 768px) {
+  .chat-sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: var(--z-modal, 400);
+    width: 85vw;
+    max-width: 320px;
+    height: 100vh;
+    transform: translateX(-100%);
+    transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    box-shadow: var(--shadow-xl);
+  }
+  .chat-sidebar-open {
+    transform: translateX(0);
+  }
+}
+
+/* ===== Backdrop ===== */
+.chat-backdrop { display: none; }
+
+@media (max-width: 768px) {
+  .chat-backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    z-index: var(--z-overlay, 300);
+    background: rgba(0, 0, 0, 0.35);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+    animation: fadeIn 200ms ease;
+  }
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+/* ===== Main Chat Area ===== */
+.chat-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  height: 100%;
+  background: var(--bg-light, #f6f8fb);
+}
+
+/* ===== Header ===== */
+.chat-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 24px;
+  background: var(--bg-primary);
+  border-bottom: 1px solid var(--border-color);
+  flex-shrink: 0;
+  min-height: 56px;
+}
+
+.chat-menu-btn {
+  display: none;
+  width: 44px;
+  height: 44px;
+  border-radius: var(--radius-lg, 12px);
+  border: none;
+  background: transparent;
+  color: var(--text-primary);
+  cursor: pointer;
+  align-items: center;
+  justify-content: center;
+  transition: background var(--transition-fast);
+}
+.chat-menu-btn:hover { background: var(--bg-tertiary); }
+
+@media (max-width: 768px) {
+  .chat-menu-btn { display: flex; }
+}
+
+.chat-header-title {
+  flex: 1;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+  color: var(--text-primary);
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  letter-spacing: var(--letter-spacing-tight);
+}
+
+.chat-expert-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--success, #22c55e);
+  box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.15);
+  animation: expertPulse 2.5s ease-in-out infinite;
+  flex-shrink: 0;
+}
+
+@keyframes expertPulse {
+  0%, 100% { opacity: 1; box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.15); }
+  50% { opacity: 0.6; box-shadow: 0 0 0 6px rgba(34, 197, 94, 0.08); }
+}
+
+.chat-new-btn {
+  width: 44px;
+  height: 44px;
+  border-radius: var(--radius-lg, 12px);
+  border: 1px solid var(--border-color);
+  background: var(--bg-primary);
+  color: var(--primary);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+}
+.chat-new-btn:hover {
+  background: var(--primary-light);
+  border-color: var(--primary);
+}
+
+/* ===== Messages Area ===== */
+.chat-messages-area {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  -webkit-overflow-scrolling: touch;
+}
+
+.chat-messages-area::-webkit-scrollbar { width: 6px; }
+.chat-messages-area::-webkit-scrollbar-track { background: transparent; }
+.chat-messages-area::-webkit-scrollbar-thumb { background: var(--border-color); border-radius: 99px; }
+
+.chat-messages-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 24px 20px;
+  max-width: 800px;
+  margin: 0 auto;
+  width: 100%;
+  min-height: 100%;
+}
+
+/* ===== Empty State ===== */
+.chat-empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 48px 24px;
+  min-height: 100%;
+  max-width: 560px;
+  margin: 0 auto;
+}
+
+.chat-empty-icon {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--primary) 0%, var(--accent, var(--primary-dark)) 100%);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 24px;
+  box-shadow: var(--shadow-primary);
+}
+
+.chat-empty-title {
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--text-primary);
+  margin: 0 0 12px;
+}
+
+.chat-empty-text {
+  font-size: var(--font-size-base);
+  color: var(--text-secondary);
+  max-width: 420px;
+  margin: 0 0 8px;
+  line-height: var(--line-height-relaxed);
+}
+
+.chat-expert-disclosure {
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  margin: 4px 0 24px;
+}
+
+/* ===== Loading ===== */
+.chat-center-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 300px;
+  gap: 16px;
+  color: var(--text-muted);
+}
+
+.chat-loading-spinner {
+  width: 36px;
+  height: 36px;
+  border: 3px solid var(--border-color);
+  border-top-color: var(--primary);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* ===== Error ===== */
+.chat-error-banner {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin: 16px 20px;
+  padding: 16px 20px;
+  background: var(--danger-light, #fee2e2);
+  color: var(--danger, #dc2626);
+  border-radius: var(--radius-xl, 16px);
+  font-size: var(--font-size-sm);
+  border: 1px solid rgba(239, 68, 68, 0.15);
+  max-width: 800px;
+  margin-left: auto;
+  margin-right: auto;
+}
+.chat-error-banner span { flex: 1; }
+.chat-error-close {
+  width: 32px; height: 32px;
+  border: none; background: transparent;
+  color: inherit; cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  border-radius: var(--radius-md);
+}
+.chat-error-close:hover { background: rgba(220, 38, 38, 0.1); }
+
+/* ===== Mobile (≤768px) ===== */
+@media (max-width: 768px) {
+  .chat-header { padding: 8px 16px; min-height: 52px; }
+  .chat-header-title { font-size: var(--font-size-base); }
+  .chat-messages-list { padding: 16px 12px; gap: 12px; }
+  .chat-empty-state { padding: 32px 16px; }
+  .chat-empty-icon { width: 64px; height: 64px; }
+  .chat-empty-title { font-size: var(--font-size-xl); }
+}
+
+/* ===== Tablet (769-1024px) ===== */
+@media (min-width: 769px) and (max-width: 1024px) {
+  .chat-sidebar { width: 240px; }
+  .chat-messages-list { max-width: 680px; }
+}
+
+/* ===== Laptop (1025-1440px) ===== */
+@media (min-width: 1025px) and (max-width: 1440px) {
+  .chat-sidebar { width: 280px; }
+  .chat-messages-list { max-width: 760px; }
+}
+
+/* ===== Desktop (1441px+) ===== */
+@media (min-width: 1441px) {
+  .chat-sidebar { width: 320px; }
+  .chat-messages-list { max-width: 800px; }
+}

--- a/frontend/src/pages/AIChatPage.tsx
+++ b/frontend/src/pages/AIChatPage.tsx
@@ -13,7 +13,7 @@ import {
   ChatSession,
   ChatMessage as ChatMessageType,
 } from '../services/chatApi';
-import styles from './AIChatPage.module.css';
+import './AIChatPage.css';
 
 const AIChatPage: React.FC = () => {
   const [sessions, setSessions] = useState<ChatSession[]>([]);
@@ -199,18 +199,18 @@ const AIChatPage: React.FC = () => {
   const hasMessages = messages.length > 0 || isStreaming;
 
   return (
-    <div className={styles.page}>
+    <div className="chat-page">
       {/* Mobile sidebar backdrop */}
       {sidebarOpen && (
         <div
-          className={styles.backdrop}
+          className="chat-backdrop"
           onClick={() => setSidebarOpen(false)}
           role="presentation"
         />
       )}
 
       {/* Sidebar */}
-      <aside className={`${styles.sidebar} ${sidebarOpen ? styles.sidebarOpen : ''}`}>
+      <aside className={`chat-sidebar ${sidebarOpen ? 'chat-sidebar-open' : ''}`}>
         <ChatSessionList
           sessions={sessionItems}
           activeSessionId={activeSessionId}
@@ -221,11 +221,11 @@ const AIChatPage: React.FC = () => {
       </aside>
 
       {/* Main chat area */}
-      <main className={styles.main}>
+      <main className="chat-main">
         {/* Header */}
-        <header className={styles.header}>
+        <header className="chat-header">
           <button
-            className={styles.menuBtn}
+            className="chat-menu-btn"
             onClick={() => setSidebarOpen((o) => !o)}
             aria-label="Toggle chat history"
             type="button"
@@ -236,12 +236,12 @@ const AIChatPage: React.FC = () => {
               <line x1="3" y1="18" x2="21" y2="18" />
             </svg>
           </button>
-          <h1 className={styles.headerTitle}>
-            <span className={styles.expertDot} />
+          <h1 className="chat-header-title">
+            <span className="chat-expert-dot" />
             Skin Expert
           </h1>
           <button
-            className={styles.newChatBtn}
+            className="chat-new-btn"
             onClick={handleCreateSession}
             aria-label="New chat"
             type="button"
@@ -254,11 +254,11 @@ const AIChatPage: React.FC = () => {
         </header>
 
         {/* Messages area */}
-        <div className={styles.messagesArea}>
+        <div className="chat-messages-area">
           {error && (
-            <div className={styles.errorBanner}>
+            <div className="chat-error-banner">
               <span>{error}</span>
-              <button onClick={() => setError(null)} className={styles.errorClose} type="button">
+              <button onClick={() => setError(null)} className="chat-error-close" type="button">
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                   <line x1="18" y1="6" x2="6" y2="18" />
                   <line x1="6" y1="6" x2="18" y2="18" />
@@ -268,28 +268,28 @@ const AIChatPage: React.FC = () => {
           )}
 
           {isLoadingSessions || isLoadingMessages ? (
-            <div className={styles.centerState}>
-              <div className={styles.loadingSpinner} />
+            <div className="chat-center-state">
+              <div className="chat-loading-spinner" />
               <p>Loading conversations...</p>
             </div>
           ) : !hasMessages ? (
-            <div className={styles.emptyState}>
-              <div className={styles.emptyIcon}>
+            <div className="chat-empty-state">
+              <div className="chat-empty-icon">
                 <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
                   <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
                 </svg>
               </div>
-              <h2 className={styles.emptyTitle}>Ask Our Skin Expert</h2>
-              <p className={styles.emptyText}>
+              <h2 className="chat-empty-title">Ask Our Skin Expert</h2>
+              <p className="chat-empty-text">
                 Get expert skincare guidance based on dermatology research, your skin profile, and scan history.
               </p>
-              <p className={styles.expertDisclosure}>
+              <p className="chat-expert-disclosure">
                 Powered by AI &middot; Not a substitute for medical advice
               </p>
               <ChatSuggestions onSelect={handleSend} />
             </div>
           ) : (
-            <div className={styles.messagesList}>
+            <div className="chat-messages-list">
               {messages.map((msg) => (
                 <ChatMessage
                   key={msg.id}


### PR DESCRIPTION
…lar CSS

Root cause: AIChatPage.module.css classes were being scoped by Vite CSS modules (e.g. .page → .AIChatPage_page_abc123) but the AppLayout wrapper and body[data-page='chat'] rules use global selectors, creating a mismatch where NO styles applied.

Fix: Converted to regular CSS with 'chat-' prefixed class names:
- AIChatPage.module.css → AIChatPage.css (regular, global classes)
- styles.page → className="chat-page"
- styles.sidebar → className="chat-sidebar"
- styles.header → className="chat-header"
- All 20+ class references converted

This matches how every other page in the app works (BlogPage.css, DashboardPage.css, ScanPage.css — all use regular CSS, not modules).

The chat sub-components (ChatMessage, ChatInput, ChatSuggestions, ChatSessionList) still use CSS modules correctly since they're self-contained components, not page-level layouts.

https://claude.ai/code/session_016XpCGMkdoVXBdD3E6dHejV

### Summary

- **What**: One-line summary of the change
- **Why**: Short justification and links to SRS/backlog

### Changes

- Files and modules changed (example: `backend/app/services/auth_service.py`)

### How to run / test locally

```bash
cd backend
pytest -q
```

### Checklist

- [ ] Tests added or updated
- [ ] Documentation updated (`docs/PROJECT_PROGRESS_TRACKER.md` or relevant doc)
- [ ] Env changes documented (`backend/.env.example`)
- [ ] DB migrations added (if schema changes)

### Notes for reviewers

- Any important notes about the change, deployment steps, or potential impacts
